### PR TITLE
Updated for rerun 0.16 and a more modern pixi version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ allowing you to setup your development environment and download demo data
 This will work with Linux and Mac
 
 Run the following in order
-1. `pixi run post-install`
-2. `pixi run download-data`
-3. `pixi run vdr`
+1`pixi run download-data`
+2`pixi run vdr`
 
 
 > **SimpleRecon: 3D Reconstruction Without 3D Convolutions**

--- a/pixi-requirements.txt
+++ b/pixi-requirements.txt
@@ -1,5 +1,0 @@
-open3d==0.17
-efficientnet_pytorch
-antialiased-cnns
-scikit-image @ https://github.com/JamieWatson683/scikit-image/archive/single_mesh.zip
-moviepy

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,920 +1,637 @@
-version: 3
-metadata:
-  content_hash:
-    linux-64: 0ab50ba93b0fb3072a2c8722fb8350cb48e3946acfc58cab265ff1e295e3d0a9
-    osx-arm64: 0ab50ba93b0fb3072a2c8722fb8350cb48e3946acfc58cab265ff1e295e3d0a9
-  channels:
-  - url: https://conda.anaconda.org/nvidia/
-    used_env_vars: []
-  - url: https://conda.anaconda.org/pytorch/
-    used_env_vars: []
-  - url: https://conda.anaconda.org/conda-forge/
-    used_env_vars: []
-  platforms:
-  - linux-64
-  - osx-arm64
-  sources: []
-  time_metadata: null
-  git_metadata: null
-  inputs_metadata: null
-  custom_metadata: null
-package:
-- platform: linux-64
+version: 4
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/nvidia/
+    - url: https://conda.anaconda.org/pytorch/
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.5-py39hd1e30aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-2.120-mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-20_linux64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py39h3d6467e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.23.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py39h7a31438_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.1-py39he6105cc_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-11.7.99-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-cupti-11.7.101-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-11.7.1-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-11.7.99-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-nvtx-11.7.91-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/cuda-runtime-11.7.1-0.tar.bz2
+      - conda: https://conda.anaconda.org/pytorch/linux-64/ffmpeg-4.3-hf484d3e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py39hd1e30aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.12.1-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.6.13-h85f3911_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.25.2-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.59.3-py39h174d805_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-70.1-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hfd0df8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_mkl.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcublas-11.10.3.66-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufft-10.7.2.124-h4fbf590_0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.8.1.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.4.101-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcusolver-11.4.0.1-0.tar.bz2
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libcusparse-11.7.4.91-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.17-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.59.3-hd6c4280_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.1-hd6dc26d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-20_linux64_mkl.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libnpp-11.7.4.75-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-11.8.0.2-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.4-hf27288f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h7a70373_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.2-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-h6adf6a1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.10.3-hca2bb57_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-17.0.6-h4dfa4b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py39hd1e30aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2023.2.0-h84fe81f_50496.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2023.2.0-ha770c72_50496.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2023.2.0-h84fe81f_50496.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.5-py39hd1e30aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.6-he412f7d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py39h474f0d3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.1.1-h780b84a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.4.0-py39h2320bf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.24.4-py39h60f6b12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydeprecate-0.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.18-h0755675_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.9-4_cp39.conda
+      - conda: https://conda.anaconda.org/pytorch/linux-64/pytorch-1.13.1-py3.9_cuda11.7_cudnn8.5.0_0.tar.bz2
+      - conda: https://conda.anaconda.org/pytorch/linux-64/pytorch-cuda-11.7-h778d358_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytorch-lightning-1.5.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyu2f-0.1.5-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py39hd1e30aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.4-py39h474f0d3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.9.0-hf52228f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tensorboard-2.15.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tensorboard-data-server-0.7.0-py39hd4f0224_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/torchmetrics-1.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/pytorch/linux-64/torchvision-0.14.1-py39_cu117.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.4-py39hd1e30aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - pypi: https://files.pythonhosted.org/packages/6a/00/b08f23b7d7e1e14ce01419a467b583edbb93c6cdb8654e54a9cc579cd61f/addict-2.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0c/73/4da776fe426722d08587baa085589c2b7d1b09dbede12e6a03881d428ac8/antialiased_cnns-0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/fe/e8c672695b37eecc5cbf43e1d0638d88d66ba3a44c4d321c796f4e59167f/beautifulsoup4-4.12.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6f/b3/b4ac838711fd74a2b4e6f746703cf9dd2cf5462d17dac07e349234e21b97/ConfigArgParse-1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/31/a2/2f12e3a6e45935ff694654b710961b03310b0e1ec997ee9f416d3c873f87/contourpy-1.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/63/22/bc266b167111e70a2da940e78b78d22fea5b1ee32b512ed0789bd6cc2a9f/dash-2.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/00/9e/a29f726e84e531a36d56cff187e61d8c96d2cc253c5bcef9a7695acb7e6a/dash_core_components-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/75/65/1b16b853844ef59b2742a7de74a598f376ac0ab581f0dcc34db294e5c90e/dash_html_components-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/da/ce/43f77dc8e7bbad02a9f88d07bf794eaf68359df756a28bb9f2f78e255bb1/dash_table-5.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/1b/72a1821152d07cf1d8b6fce298aeb06a7eb90f4d6d41acec9861e7cc6df0/decorator-4.4.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/a0/dd40b50aebf0028054b6b35062948da01123d7be38d08b6b1e5435df6363/efficientnet_pytorch-0.7.1.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/44/5a/f0b9ad6c0a9017e62d4735daaeb11ba3b6c009d69a26141b258cd37b5588/einops-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/01/90/79fe92dd413a9cab314ef5c591b5aa9b9ba787ae4cadab75055b0ae00b33/exceptiongroup-1.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/03/6ea8b1b2a5ab40a7a60dc464d3daa7aa546e0a74d74a9f8ff551ea7905db/executing-2.0.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/b9/79691036d4a8f9857e74d1728b23f34f583b81350a27492edda58d5604e1/fastjsonschema-2.19.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/24/0b023b6537dfc9bae2c779353998e3e99ac7dfff4222fc6126650e93c3f3/filelock-3.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/80/ffe1da13ad9300f87c93af113edd0638c75138c42a0994becfacac078c06/flask-3.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/c6/636f008104908a93b80419f756be755bb91df4b8a0c88d5158bb52c82c3a/fonttools-4.51.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/34/76cfe866e482745ea8c9956b0be6198fd72d08d2be77b71596afdb8cd89f/freetype_py-2.4.0-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/54/70/e07c381e6488a77094f04c85c9caf1c8008cdc30778f7019bc52e5285ef0/gdown-5.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/21/2b/516f82c5ba9beb184b24c11976be2ad5e80fb7fe6b2796c887087144445e/huggingface_hub-0.23.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/b6/39c7dad203d9984225f47e0aa39ac3ba3a47c77a02d0ef2a7be691855a06/imageio-2.34.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1a/98/3df1d8dd8f2c121b6c588b1e0d604f36592d56df9c41fb155ed546c6a5ed/imageio_ffmpeg-0.4.9-py3-none-manylinux2010_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/75/06/4df55e1b7b112d183f65db9503bff189e97179b256e1ea450a3c365241e0/importlib_resources-6.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/47/6b/d9fdcdef2eb6a23f391251fde8781c38d42acd82abe84d054cb74f7863b0/ipython-8.18.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/1a/7edeedb1c089d63ccd8bd5c0612334774e90cf9337de9fe6c82d90081791/ipywidgets-8.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/9f/bc63f0f0737ad7a60800bfd472a4836661adae21f9c2535f3957b1e54ceb/jedi-0.19.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/91/29/df4b9b42f2be0b623cbd5e2140cafcaa2bef0759a00b7b70104dcfe2fb51/joblib-1.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/2f/324fab4be6fe37fb7b521546e8a557e6cf08c1c1b3d0b4839a00f589d9ef/jsonschema-4.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ee/07/44bd408781594c4d0a027666ef27fab1e441b109dc3b76b4f836f8fd04fe/jsonschema_specifications-2023.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/fb/108ecd1fe961941959ad0ee4e12ee7b8b1477247f30b1fdfd83ceaf017f0/jupyter_core-5.7.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/24/da/db1cb0387a7e4086780aff137987ee924e953d7f91b2a870f994b9b1eeb8/jupyterlab_widgets-3.0.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c0/a8/841594f11d0b88d8aeb26991bc4dac38baa909dc58d0c4262a4f7893bcbf/kiwisolver-1.4.5-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/7f/5ec91cec58e02a41b1b0ea0fe9f0b2506cb68d497cf94382d464b2af77f4/kornia-0.6.7-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/83/60/d497a310bde3f01cb805196ac61b7ad6dc5dcf8dce66634dc34364b20b4f/lazy_loader-0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5e/2c/513395a63a9e1124a5648addbf73be23cc603f955af026b04416da98dc96/matplotlib-3.8.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/54/01a8c4e35c75ca9724d19a7e4de9dc23f0ceb8769102c7de056113af61c3/moviepy-1.0.3.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/f0/8fbc882ca80cf077f1b246c0e3c3465f7f415439bdea6b899f6b19f61f70/networkx-3.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/36/00032c1f99f67ec9d0afdb4bcb2561f78a9f5feaafdabd1043e12a6f9b6e/open3d-0.18.0-cp39-cp39-manylinux_2_27_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/bb/30/f6f1f1ac36250f50c421b1b6af08c35e5a8b5a84385ef928625336b93e6f/pandas-2.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/f8/b65cdd2be32e442c4efe7b672f73c90b05eab5a7f3f4115efe181d432c60/plotly-5.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/f5/cab5cf6a540c31f5099043de0ae43990fd9cf66f75ecb5e9f254a4e4d4ee/proglog-0.1.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ee/fd/ca7bf3869e7caa7a037e23078539467b433a4e01eebd93f77180ab927766/prompt_toolkit-3.0.43-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2b/27/77f9d5684e6bce929f5cfe18d6cfbe5133013c06cb2fbf5933670e60761d/pure_eval-0.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4a/0e/ca72b2e27d8d7a23e9866c819436ebeb518f934ac2b8b871fab373f9c859/pyarrow-16.1.0-cp39-cp39-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/30/93/4d02ac696f16a2ad8fff0e78be28ab4ec0b990d2b3569fe07e27a258cb02/pyglet-2.0.15-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/1d/4544708aaa89f26c97cc09450bb333a23724a320923e74d73e028b3560f9/PyOpenGL-3.1.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/49/b3/d8482e8cacc8ea15a356efea13d22ce1c5914a9ee36622ba250523240bf2/pyquaternion-0.9.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/88/174c28b9d3d03cf6d8edb6f637458f30f1cf1a2bd7a617cbd9dadb1740f6/pyrender-0.1.45-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/3d/a121f284241f08268b21359bd425f7d4825cffc5ac5cd0e1b3d82ffd2b10/pytz-2024.1-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/59/2056f61236782a2c86b33906c025d4f4a0b17be0161b63b70fd9e8775d36/referencing-0.35.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/25/22/c6094d03eddbf051e8e2eb5621d062d90e1b3e9bd11284cf38dc0bb53c5e/rerun_sdk-0.16.0rc4-cp38-abi3-manylinux_2_31_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8f/04/9e36f28be4c0532c0e9207ff9dc01fb13a2b0eb036476a213b0000837d0e/retrying-1.3.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/97/b1/12238bd8cdf3cef71e85188af133399bfde1bddf319007361cc869d6f6a7/rpds_py-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/38/7f/3ba803bd6d726d65e480bee2aaeea79580d2e4836e4c6ebc27144c62ce51/safetensors-0.4.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/7e/4cd853a855ac34b4ef3ef6a5c3d1c2e96eaca1154fc6be75db55ffa87393/scikit_image-0.22.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/82/40/5906b7ae6e303ece856a4262b0e7a963eb0187c167b539ff87bc1fe8f887/scikit_learn-1.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/4c/f3/038b302fdfbe3be7da016777069f26ceefe11a681055ea1f7817546508e3/soupsieve-2.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/a1/6bb0cbebefb23641f068bb58a2bc56da9beb2b1c550242e3c540b37698f3/tenacity-8.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/79/29d0fa40017f7b749ce344759dcc21e2ec9bbb81fc69ca2ce06e261f83f0/tifffile-2024.5.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/19/0d/57fe21d3bcba4832ed59bc3bf0f544e8f0011f8ccd6fd85bc8e2a5d42c94/timm-1.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/94/65e0fe886c6d5c86f4a0552dc98f49f9ed9d77c4d925a0af97d48a8226de/transforms3d-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/57/7b/557a411622ff3e144d52bebbf8ad8a28bb18ee55ff68e1eb5ebfce755975/trimesh-4.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/bc/82a8c3985209ca7c0a61b383c80e015fd92e74f8ba0ec1af98f9d6ca8dce/widgetsnbextension-4.0.10-py3-none-any.whl
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.9.5-py39h17cfd9d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.6.1-hb765f3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py39hb198ff7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.28.1-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.11.17-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py39he153c15_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-42.0.2-py39hbc7c26c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-5.1.2-gpl_h9861f02_112.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.4.1-py39h17cfd9d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.12.1-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h965bd2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.25.2-pyhca7485f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.60.0-py39h047a24b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.3.0-h8f0ba13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jpeg-9e-h1a8c8d9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-h481adae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-20_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-20_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.17-h1a8c8d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.3-hb438215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.60.0-hfc68871_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.4-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-20_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.25-openmp_h6c19121_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.1-h810fc01_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.06.02-h1753957_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.44.2-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.5.0-h5dffbdd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.13.1-hb765f3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.13-h9b22ae9_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.6-h0d0cfa8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.6-hcd81f8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.5-py39h17cfd9d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.0.5-py39h02fc5c5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py39h7aa2656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.3.1-hb7217d7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-hbc2ba62_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.0-h0d3ecfb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.42-h26f9a81_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.4.0-py39h8bd98a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.42.2-h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/protobuf-4.25.1-py39haf112ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydeprecate-0.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.18-hd7ebdb9_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.9-4_cp39.conda
+      - conda: https://conda.anaconda.org/pytorch/osx-arm64/pytorch-1.13.1-py3.9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytorch-lightning-1.5.4-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyu2f-0.1.5-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py39h0f82c59_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.06.02-h6135d0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.4-py39h36c428d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.4.1-h7ea286d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tensorboard-2.15.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tensorboard-data-server-0.7.0-py39had97604_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/torchmetrics-1.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/pytorch/osx-arm64/torchvision-0.14.1-py39_cpu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.9.4-py39h17cfd9d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+      - pypi: https://files.pythonhosted.org/packages/0c/73/4da776fe426722d08587baa085589c2b7d1b09dbede12e6a03881d428ac8/antialiased_cnns-0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b1/fe/e8c672695b37eecc5cbf43e1d0638d88d66ba3a44c4d321c796f4e59167f/beautifulsoup4-4.12.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/f5/8a0e688c3a6098a358fa359da6a09a7b9afd8f3f6c9b83e9898c29e87b95/contourpy-1.2.1-cp39-cp39-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/1b/72a1821152d07cf1d8b6fce298aeb06a7eb90f4d6d41acec9861e7cc6df0/decorator-4.4.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/a0/dd40b50aebf0028054b6b35062948da01123d7be38d08b6b1e5435df6363/efficientnet_pytorch-0.7.1.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/44/5a/f0b9ad6c0a9017e62d4735daaeb11ba3b6c009d69a26141b258cd37b5588/einops-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/24/0b023b6537dfc9bae2c779353998e3e99ac7dfff4222fc6126650e93c3f3/filelock-3.14.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3e/d8/db820b6243325f29e93de36273fdd48f3c1dce7fa859be5ed3708e174eba/fonttools-4.51.0-cp39-cp39-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/7c/77/faec42d1ffac2b970f606860a5bb083d606f1c673a5c57ab26382c8efec1/freetype_py-2.4.0-py3-none-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/54/70/e07c381e6488a77094f04c85c9caf1c8008cdc30778f7019bc52e5285ef0/gdown-5.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/21/2b/516f82c5ba9beb184b24c11976be2ad5e80fb7fe6b2796c887087144445e/huggingface_hub-0.23.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/b6/39c7dad203d9984225f47e0aa39ac3ba3a47c77a02d0ef2a7be691855a06/imageio-2.34.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/c6/7f9990d8f9378bb4b8c60c08c2a1f565c44d9445c1f01fbbd5bed21379d9/imageio-ffmpeg-0.4.9.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/75/06/4df55e1b7b112d183f65db9503bff189e97179b256e1ea450a3c365241e0/importlib_resources-6.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/89/a8/3b7e14121bea4438b87630557645bb7648b17b54acaa39b93f4bf7f8d33e/kiwisolver-1.4.5-cp39-cp39-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/7a/7f/5ec91cec58e02a41b1b0ea0fe9f0b2506cb68d497cf94382d464b2af77f4/kornia-0.6.7-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/83/60/d497a310bde3f01cb805196ac61b7ad6dc5dcf8dce66634dc34364b20b4f/lazy_loader-0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d5/88/83aee628339486de57fcc8c1387e28de816182edcfc42928cff02c364664/matplotlib-3.8.4-cp39-cp39-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/18/54/01a8c4e35c75ca9724d19a7e4de9dc23f0ceb8769102c7de056113af61c3/moviepy-1.0.3.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/d5/f0/8fbc882ca80cf077f1b246c0e3c3465f7f415439bdea6b899f6b19f61f70/networkx-3.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/70/60/bd0553ded5d16d5834145184d4a53321fdf78c31b82c83764ef12b6d8c91/open3d-0.15.1-cp39-cp39-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/f5/cab5cf6a540c31f5099043de0ae43990fd9cf66f75ecb5e9f254a4e4d4ee/proglog-0.1.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e3/12/635c509b84c50cd92fa35a2dee8bc9c1f6fc042da86276ca726f24c5d87f/pyarrow-16.1.0-cp39-cp39-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/30/93/4d02ac696f16a2ad8fff0e78be28ab4ec0b990d2b3569fe07e27a258cb02/pyglet-2.0.15-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/1d/4544708aaa89f26c97cc09450bb333a23724a320923e74d73e028b3560f9/PyOpenGL-3.1.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/88/174c28b9d3d03cf6d8edb6f637458f30f1cf1a2bd7a617cbd9dadb1740f6/pyrender-0.1.45-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4e/65/181a8e55e867b5870d6f6b9217aabd93cdea77e2c8547873e98d154bb5c9/rerun_sdk-0.16.0rc4-cp38-abi3-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/c2/2b/bdfdc24feb4cb02f49f55e9233253cd27d101215f81a248a7dbcfd590356/safetensors-0.4.3-cp39-cp39-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/65/c1/a49da20845f0f0e1afbb1c2586d406dc0acb84c26ae293bad6d7e7f718bc/scikit_image-0.22.0.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/4c/f3/038b302fdfbe3be7da016777069f26ceefe11a681055ea1f7817546508e3/soupsieve-2.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/79/29d0fa40017f7b749ce344759dcc21e2ec9bbb81fc69ca2ce06e261f83f0/tifffile-2024.5.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/19/0d/57fe21d3bcba4832ed59bc3bf0f544e8f0011f8ccd6fd85bc8e2a5d42c94/timm-1.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/56/94/65e0fe886c6d5c86f4a0552dc98f49f9ed9d77c4d925a0af97d48a8226de/transforms3d-0.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/57/7b/557a411622ff3e144d52bebbf8ad8a28bb18ee55ff68e1eb5ebfce755975/trimesh-4.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl
+packages:
+- kind: conda
   name: _libgcc_mutex
   version: '0.1'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
-  hash:
-    md5: d7c89558ba9fa0495403155b64376d81
-    sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   build: conda_forge
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  arch: x86_64
+  platform: linux
   license: None
   size: 2562
   timestamp: 1578324546067
-- platform: linux-64
+- kind: conda
   name: _openmp_mutex
   version: '4.5'
-  category: main
-  manager: conda
-  dependencies:
+  build: 2_kmp_llvm
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
+  sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
+  md5: 562b26ba2e19059551a811e72ab7f793
+  depends:
   - _libgcc_mutex 0.1 conda_forge
   - llvm-openmp >=9.0.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_kmp_llvm.tar.bz2
-  hash:
-    md5: 562b26ba2e19059551a811e72ab7f793
-    sha256: 84a66275da3a66e3f3e70e9d8f10496d807d01a9e4ec16cd2274cc5e28c478fc
-  build: 2_kmp_llvm
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 5744
   timestamp: 1650742457817
-- platform: linux-64
+- kind: conda
   name: absl-py
   version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2361c56617987bb6623dcbf8bab5cdc4
-    sha256: 99e2a54d079d91909d6d12d2336d792fd2ab666620d2ac761cd09d0e552dd44d
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 105179
-  timestamp: 1695154668784
-- platform: osx-arm64
-  name: absl-py
-  version: 2.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.0.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2361c56617987bb6623dcbf8bab5cdc4
-    sha256: 99e2a54d079d91909d6d12d2336d792fd2ab666620d2ac761cd09d0e552dd44d
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/absl-py-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 99e2a54d079d91909d6d12d2336d792fd2ab666620d2ac761cd09d0e552dd44d
+  md5: 2361c56617987bb6623dcbf8bab5cdc4
+  depends:
+  - python >=3.6
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
-  noarch: python
+  purls:
+  - pkg:pypi/absl-py
   size: 105179
   timestamp: 1695154668784
-- platform: linux-64
+- kind: pypi
+  name: addict
+  version: 2.4.0
+  url: https://files.pythonhosted.org/packages/6a/00/b08f23b7d7e1e14ce01419a467b583edbb93c6cdb8654e54a9cc579cd61f/addict-2.4.0-py3-none-any.whl
+  sha256: 249bb56bbfd3cdc2a004ea0ff4c2b6ddc84d53bc2194761636eb314d5cfa5dfc
+- kind: conda
   name: aiohttp
-  version: 3.9.1
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.9.5
+  build: py39h17cfd9d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.9.5-py39h17cfd9d_0.conda
+  sha256: 3f0a18b8136ec8c0ab7b2fe96c7b0c5b89782dff430254506b27ab0d774ac352
+  md5: 028d1bf2a6bb408f0bd21dafd667d801
+  depends:
+  - aiosignal >=1.1.2
+  - async-timeout >=4.0,<5.0
+  - attrs >=17.3.0
+  - frozenlist >=1.1.1
+  - multidict >=4.5,<7.0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  - yarl >=1.0,<2.0
+  license: MIT AND Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/aiohttp
+  size: 662562
+  timestamp: 1713965235056
+- kind: conda
+  name: aiohttp
+  version: 3.9.5
+  build: py39hd1e30aa_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.5-py39hd1e30aa_0.conda
+  sha256: 7d1d392e277705ac53c8b072792a8208b58dd0d27eae5ae87f1c0704cdb9cc67
+  md5: 9c382758cef31bd302f2ebbab7a31e4d
+  depends:
   - aiosignal >=1.1.2
   - async-timeout >=4.0,<5.0
   - attrs >=17.3.0
   - frozenlist >=1.1.1
   - libgcc-ng >=12
   - multidict >=4.5,<7.0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   - yarl >=1.0,<2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.9.1-py310h2372a71_0.conda
-  hash:
-    md5: f367877549376e985a3df1dc430692ae
-    sha256: 6a3983f2ee81308ae0716790ae780f63915f47fcd6a1038d3c75a78fcb675f23
-  build: py310h2372a71_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   license: MIT AND Apache-2.0
   license_family: Apache
-  size: 692799
-  timestamp: 1701099634545
-- platform: osx-arm64
-  name: aiohttp
-  version: 3.9.1
-  category: main
-  manager: conda
-  dependencies:
-  - aiosignal >=1.1.2
-  - async-timeout >=4.0,<5.0
-  - attrs >=17.3.0
-  - frozenlist >=1.1.1
-  - multidict >=4.5,<7.0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - yarl >=1.0,<2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.9.1-py310hd125d64_0.conda
-  hash:
-    md5: 23e26e27bec695a368aebc1befa3cd6c
-    sha256: 92fce5904a0af48a2e3eb9564f777017825adf33a25194cedaefdb667a72d82d
-  build: py310hd125d64_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT AND Apache-2.0
-  license_family: Apache
-  size: 662082
-  timestamp: 1701100051071
-- platform: linux-64
+  purls:
+  - pkg:pypi/aiohttp
+  size: 693203
+  timestamp: 1713964945016
+- kind: conda
   name: aiosignal
   version: 1.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - frozenlist >=1.1.0
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: d1e1eb7e21a9e2c74279d87dafb68156
-    sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 12730
-  timestamp: 1667935912504
-- platform: osx-arm64
-  name: aiosignal
-  version: 1.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - frozenlist >=1.1.0
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: d1e1eb7e21a9e2c74279d87dafb68156
-    sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 575c742e14c86575986dc867463582a970463da50b77264cdf54df74f5563783
+  md5: d1e1eb7e21a9e2c74279d87dafb68156
+  depends:
+  - frozenlist >=1.1.0
+  - python >=3.7
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
+  purls:
+  - pkg:pypi/aiosignal
   size: 12730
   timestamp: 1667935912504
-- platform: linux-64
-  name: alsa-lib
-  version: 1.2.8
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.8-h166bdaf_0.tar.bz2
-  hash:
-    md5: be733e69048951df1e4b4b7bb8c7666f
-    sha256: 2c0a618d0fa695e4e01a30e7ff31094be540c52e9085cbd724edb132c65cf9cd
-  build: h166bdaf_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.1-or-later
-  license_family: GPL
-  size: 592320
-  timestamp: 1666699031168
-- platform: osx-arm64
+- kind: pypi
+  name: antialiased-cnns
+  version: '0.3'
+  url: https://files.pythonhosted.org/packages/0c/73/4da776fe426722d08587baa085589c2b7d1b09dbede12e6a03881d428ac8/antialiased_cnns-0.3-py3-none-any.whl
+  sha256: 0c740d37dd971c94491755edcce79d9144523107af53b44bce7acc681896f27d
+- kind: conda
   name: aom
   version: 3.6.1
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.6.1-hb765f3a_0.conda
-  hash:
-    md5: efe2c75abcf259999d1779bbbc9cd3ce
-    sha256: 71e86411093a5241fa9349b61e0c42a841d39364b8298bd80919ede75fc496bd
   build: hb765f3a_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.6.1-hb765f3a_0.conda
+  sha256: 71e86411093a5241fa9349b61e0c42a841d39364b8298bd80919ede75fc496bd
+  md5: efe2c75abcf259999d1779bbbc9cd3ce
+  depends:
+  - libcxx >=15.0.7
+  arch: aarch64
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 2067686
   timestamp: 1694226240409
-- platform: linux-64
+- kind: pypi
+  name: asttokens
+  version: 2.4.1
+  url: https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl
+  sha256: 051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24
+  requires_dist:
+  - six>=1.12.0
+  - typing ; python_version < '3.5'
+  - astroid<2,>=1 ; python_version < '3' and extra == 'astroid'
+  - astroid<4,>=2 ; python_version >= '3' and extra == 'astroid'
+  - pytest ; extra == 'test'
+  - astroid<2,>=1 ; python_version < '3' and extra == 'test'
+  - astroid<4,>=2 ; python_version >= '3' and extra == 'test'
+- kind: conda
   name: async-timeout
   version: 4.0.3
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
+  sha256: bd8b698e7f037a9c6107216646f1191f4f7a7fc6da6c34d1a6d4c211bcca8979
+  md5: 3ce482ec3066e6d809dbbb1d1679f215
+  depends:
   - python >=3.7
   - typing-extensions >=3.6.5
-  url: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ce482ec3066e6d809dbbb1d1679f215
-    sha256: bd8b698e7f037a9c6107216646f1191f4f7a7fc6da6c34d1a6d4c211bcca8979
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
-  noarch: python
+  purls:
+  - pkg:pypi/async-timeout
   size: 11352
   timestamp: 1691763717537
-- platform: osx-arm64
-  name: async-timeout
-  version: 4.0.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - typing-extensions >=3.6.5
-  url: https://conda.anaconda.org/conda-forge/noarch/async-timeout-4.0.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3ce482ec3066e6d809dbbb1d1679f215
-    sha256: bd8b698e7f037a9c6107216646f1191f4f7a7fc6da6c34d1a6d4c211bcca8979
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 11352
-  timestamp: 1691763717537
-- platform: linux-64
-  name: attr
-  version: 2.5.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
-  hash:
-    md5: d9c69a24ad678ffce24c6543a0176b00
-    sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
-  build: h166bdaf_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 71042
-  timestamp: 1660065501192
-- platform: linux-64
+- kind: conda
   name: attrs
   version: 23.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
-  hash:
-    md5: 3edfead7cedd1ab4400a6c588f3e75f8
-    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
   build: pyh71513ae_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  md5: 3edfead7cedd1ab4400a6c588f3e75f8
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/attrs
   size: 55022
   timestamp: 1683424195402
-- platform: osx-arm64
-  name: attrs
-  version: 23.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
-  hash:
-    md5: 3edfead7cedd1ab4400a6c588f3e75f8
-    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
-  build: pyh71513ae_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 55022
-  timestamp: 1683424195402
-- platform: linux-64
-  name: aws-c-auth
-  version: 0.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-cal >=0.6.0,<0.6.1.0a0
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - aws-c-http >=0.7.11,<0.7.12.0a0
-  - aws-c-io >=0.13.28,<0.13.29.0a0
-  - aws-c-sdkutils >=0.1.11,<0.1.12.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.0-hf8751d9_2.conda
-  hash:
-    md5: deb12196f0c64c441bb3d083d06d0cf8
-    sha256: 5d395120841ab893e160188e253d0bca767a6c7b7b4cbf315d916bcd295dbc72
-  build: hf8751d9_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 102046
-  timestamp: 1689055622716
-- platform: osx-arm64
-  name: aws-c-auth
-  version: 0.7.8
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-http >=0.7.14,<0.7.15.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.8-h1daab45_1.conda
-  hash:
-    md5: c371d15f81c1d3ef867eb480a33259ce
-    sha256: 1ff92feeb1c69add6fa4c7d667e56ab725abd31b017cf7bb8aba04d9078b0f01
-  build: h1daab45_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: Apache-2.0
-  license_family: Apache
-  size: 88752
-  timestamp: 1701263578085
-- platform: linux-64
-  name: aws-c-cal
-  version: 0.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - libgcc-ng >=12
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.0-h93469e0_0.conda
-  hash:
-    md5: 580a52a05f5be28ce00764149017c6d4
-    sha256: fa5c1d66a018f2d8cfae25fd5c4ae74e9dd0feb87079a7c57e2f836b7bf2bd46
-  build: h93469e0_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 50478
-  timestamp: 1688147288210
-- platform: osx-arm64
-  name: aws-c-cal
-  version: 0.6.9
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-hb1772db_2.conda
-  hash:
-    md5: 412ec63d1ac917e45f3206dd29dcc7e8
-    sha256: 7059960c1e765461227da57112fa3aabcef2292c83499d0440da46ec938ba017
-  build: hb1772db_2
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 39662
-  timestamp: 1701212885323
-- platform: linux-64
-  name: aws-c-common
-  version: 0.8.23
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.8.23-hd590300_0.conda
-  hash:
-    md5: cc4f06f7eedb1523f3b83fd0fb3942ff
-    sha256: 4edd0006e7b0c46de33968585cf085bb3c133ec9a25a9681b3fb7adda92d31cd
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 196823
-  timestamp: 1686147514634
-- platform: osx-arm64
-  name: aws-c-common
-  version: 0.9.10
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.10-h93a5062_0.conda
-  hash:
-    md5: 7b7bd1f14689ddec8131a0c4111790ca
-    sha256: 3269c3773d02262132cff14819bb606360c2ca44cdf9373e1a67f118c7a5232b
-  build: h93a5062_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 204196
-  timestamp: 1701169900533
-- platform: linux-64
-  name: aws-c-compression
-  version: 0.2.17
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h862ab75_1.conda
-  hash:
-    md5: 0013fcee7acb3cfc801c5929824feb3c
-    sha256: 4ee24a5dcd00cf72b3ce9e8dc4e7d209e42ec34a04ef750c0fc026dee8e3a906
-  build: h862ab75_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: Apache
-  size: 19003
-  timestamp: 1686246885957
-- platform: osx-arm64
-  name: aws-c-compression
-  version: 0.2.17
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-hb1772db_7.conda
-  hash:
-    md5: 5363bbd9ffcea69e9ef383766dcc49e0
-    sha256: e74330ffc64ac9bd9eb89c1e9d1004fe9b2aa689ecf8d5a94fdb17438237659b
-  build: hb1772db_7
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 7
-  license: Apache-2.0
-  license_family: Apache
-  size: 18255
-  timestamp: 1701212799172
-- platform: linux-64
-  name: aws-c-event-stream
-  version: 0.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - aws-c-io >=0.13.28,<0.13.29.0a0
-  - aws-checksums >=0.1.16,<0.1.17.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.1-h9599702_1.conda
-  hash:
-    md5: a8820ce2dbe6f7d54f6540d9a3a0028a
-    sha256: a1cb7e820f97f166a2e5a547362272a3d1c14d7619264221a3a5fb0faa84712e
-  build: h9599702_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: Apache
-  size: 54033
-  timestamp: 1688890164137
-- platform: osx-arm64
-  name: aws-c-event-stream
-  version: 0.3.2
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  - libcxx >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-hb5e90b3_8.conda
-  hash:
-    md5: 43263bfb2e9a2cc4162bcf90ce9c73b9
-    sha256: c9495e5133feacacef792a8f3101f1e44464144c603fccd7f1b6262975983094
-  build: hb5e90b3_8
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 8
-  license: Apache-2.0
-  license_family: Apache
-  size: 47429
-  timestamp: 1701263443184
-- platform: linux-64
-  name: aws-c-http
-  version: 0.7.11
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-cal >=0.6.0,<0.6.1.0a0
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - aws-c-compression >=0.2.17,<0.2.18.0a0
-  - aws-c-io >=0.13.28,<0.13.29.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.11-hbe98c3e_0.conda
-  hash:
-    md5: 067641478d8f706b80a5a434a22b82be
-    sha256: 68df6ec71e002a389405831231a35b671ad6ef1d6629f10c7129030aa79040e7
-  build: hbe98c3e_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 193802
-  timestamp: 1689018064399
-- platform: osx-arm64
-  name: aws-c-http
-  version: 0.7.14
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-compression >=0.2.17,<0.2.18.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.14-hd747585_3.conda
-  hash:
-    md5: 7c2b05d673ad261a1fb5711350e645a5
-    sha256: 71dc46c49e033aa3eedb43433981334b85623f7b7ea6b65ea99d9bb0cd0a2f46
-  build: hd747585_3
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 3
-  license: Apache-2.0
-  license_family: Apache
-  size: 150984
-  timestamp: 1701248891898
-- platform: linux-64
-  name: aws-c-io
-  version: 0.13.28
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-cal >=0.6.0,<0.6.1.0a0
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - libgcc-ng >=12
-  - s2n >=1.3.46,<1.3.47.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.28-h3870b5a_0.conda
-  hash:
-    md5: b775667301ab249f94ad2bea91fc4223
-    sha256: 9d9919c6f09f56b1bc6f62e480301cd9572c532244e0977c08f316971a8bb7d5
-  build: h3870b5a_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 154905
-  timestamp: 1688675079186
-- platform: osx-arm64
-  name: aws-c-io
-  version: 0.13.36
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.36-h1112932_2.conda
-  hash:
-    md5: f1cc3b657bd5c4ba8e9f9ea0bd526478
-    sha256: f4cbb1bbe3afc2391d8a15cd89549a700bb7f066bb4056283dbea3317be63925
-  build: h1112932_2
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 136652
-  timestamp: 1702039441322
-- platform: linux-64
-  name: aws-c-mqtt
-  version: 0.8.14
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - aws-c-http >=0.7.11,<0.7.12.0a0
-  - aws-c-io >=0.13.28,<0.13.29.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.8.14-h2e270ba_2.conda
-  hash:
-    md5: 58bbee5fd6cf2d4fffbead1bc33a5d3b
-    sha256: c3e24bf4b36a09b91d55f16a3c0703eeb6fad9417e63d696dc81c1800ce633d7
-  build: h2e270ba_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 153691
-  timestamp: 1689056217537
-- platform: osx-arm64
-  name: aws-c-mqtt
-  version: 0.9.10
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-http >=0.7.14,<0.7.15.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.10-h99ceed4_2.conda
-  hash:
-    md5: e65083cbeba6dd468c960107b08d89d3
-    sha256: 537ea079e4d44606134f64220d4676afe16487470725d8075778017ae3d8e9eb
-  build: h99ceed4_2
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 118280
-  timestamp: 1701264068201
-- platform: linux-64
-  name: aws-c-s3
-  version: 0.3.13
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-auth >=0.7.0,<0.7.1.0a0
-  - aws-c-cal >=0.6.0,<0.6.1.0a0
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - aws-c-http >=0.7.11,<0.7.12.0a0
-  - aws-c-io >=0.13.28,<0.13.29.0a0
-  - aws-checksums >=0.1.16,<0.1.17.0a0
-  - libgcc-ng >=12
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.3.13-heb0bb06_2.conda
-  hash:
-    md5: c0866da05d5e7bb3a3f6b68bcbf7537b
-    sha256: 82ee8401281738b2f6fe611eeef0204aa26182141e6f317bdc320dbe22a1c00f
-  build: heb0bb06_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 86928
-  timestamp: 1689070030989
-- platform: osx-arm64
-  name: aws-c-s3
-  version: 0.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-auth >=0.7.8,<0.7.9.0a0
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-http >=0.7.14,<0.7.15.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.4.1-hc25d294_2.conda
-  hash:
-    md5: e84f01eda9deb24870e839b919859e55
-    sha256: 041d9f3603b5f1d3d2cb6b1fe67a630640eb68f57dae0595b376c128a15c4e6b
-  build: hc25d294_2
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 81363
-  timestamp: 1701277829841
-- platform: linux-64
-  name: aws-c-sdkutils
-  version: 0.1.11
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.11-h862ab75_1.conda
-  hash:
-    md5: 6fbc9bd49434eb36d3a59c5020f4af95
-    sha256: 0e3f1693008657861babe98a156b91ca40d1627576c84ddd89b081fcc3238a8c
-  build: h862ab75_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: Apache
-  size: 53276
-  timestamp: 1686246736119
-- platform: osx-arm64
-  name: aws-c-sdkutils
-  version: 0.1.12
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.12-hb1772db_6.conda
-  hash:
-    md5: b1c267ceb24fa4c715d716167741e79e
-    sha256: ca11f22101f40114a28911fd92b13b8ca487e802311ab20c3a2af39d39eed1a6
-  build: hb1772db_6
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 6
-  license: Apache-2.0
-  license_family: Apache
-  size: 46834
-  timestamp: 1701221080929
-- platform: linux-64
-  name: aws-checksums
-  version: 0.1.16
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.16-h862ab75_1.conda
-  hash:
-    md5: f883d61afbc95c50f7b3f62546da4235
-    sha256: 371781536ae339b65f57d13f32f3c8c62e95ebd68021f06d34522fb0b9f8374f
-  build: h862ab75_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: Apache
-  size: 50116
-  timestamp: 1686241061277
-- platform: osx-arm64
-  name: aws-checksums
-  version: 0.1.17
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-hb1772db_6.conda
-  hash:
-    md5: da58c3c6dcf40cfa69a0a74a7acf355c
-    sha256: 9c72adde6dd106aa0ce0bc21252a9a5c9645c9efb93b5f9c08a914e45a3ad78c
-  build: hb1772db_6
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 6
-  license: Apache-2.0
-  license_family: Apache
-  size: 49237
-  timestamp: 1701247014330
-- platform: linux-64
-  name: aws-crt-cpp
-  version: 0.20.3
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-auth >=0.7.0,<0.7.1.0a0
-  - aws-c-cal >=0.6.0,<0.6.1.0a0
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - aws-c-event-stream >=0.3.1,<0.3.2.0a0
-  - aws-c-http >=0.7.11,<0.7.12.0a0
-  - aws-c-io >=0.13.28,<0.13.29.0a0
-  - aws-c-mqtt >=0.8.14,<0.8.15.0a0
-  - aws-c-s3 >=0.3.13,<0.3.14.0a0
-  - aws-c-sdkutils >=0.1.11,<0.1.12.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.20.3-he9c0e7f_4.conda
-  hash:
-    md5: 7695770e1d722ce9029a2ea30c060a3d
-    sha256: 76c5e41f38279e5e78854bcc8ae8333e84df6d898a5a2179d2203d03ba3943e2
-  build: he9c0e7f_4
-  arch: x86_64
-  subdir: linux-64
-  build_number: 4
-  license: Apache-2.0
-  license_family: Apache
-  size: 321386
-  timestamp: 1689085455254
-- platform: osx-arm64
-  name: aws-crt-cpp
-  version: 0.24.8
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - aws-c-auth >=0.7.8,<0.7.9.0a0
-  - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
-  - aws-c-http >=0.7.14,<0.7.15.0a0
-  - aws-c-io >=0.13.36,<0.13.37.0a0
-  - aws-c-mqtt >=0.9.10,<0.9.11.0a0
-  - aws-c-s3 >=0.4.1,<0.4.2.0a0
-  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
-  - libcxx >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.24.8-h969500a_2.conda
-  hash:
-    md5: ef6bccc0704ad4eab136b454aec37a6b
-    sha256: cfef8cc14b5f609e535cd3500cff36c6dc6440cf63fb43402cef7c68cf6f9307
-  build: h969500a_2
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 214923
-  timestamp: 1701293674010
-- platform: linux-64
-  name: aws-sdk-cpp
-  version: 1.10.57
-  category: main
-  manager: conda
-  dependencies:
-  - aws-c-common >=0.8.23,<0.8.24.0a0
-  - aws-c-event-stream >=0.3.1,<0.3.2.0a0
-  - aws-crt-cpp >=0.20.3,<0.20.4.0a0
-  - libcurl >=8.1.2,<9.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.10.57-hbc2ea52_17.conda
-  hash:
-    md5: 452c7b08c21eea2ef01f4fd364d6affc
-    sha256: 806ee5d9fb255f7c327c45347935611dfb2988ec47438772935617215233c487
-  build: hbc2ea52_17
-  arch: x86_64
-  subdir: linux-64
-  build_number: 17
-  license: Apache-2.0
-  license_family: Apache
-  size: 4047429
-  timestamp: 1688892415879
-- platform: osx-arm64
-  name: aws-sdk-cpp
-  version: 1.11.210
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - aws-c-common >=0.9.10,<0.9.11.0a0
-  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.24.8,<0.24.9.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libcxx >=16.0.6
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.210-hff40170_2.conda
-  hash:
-    md5: f495893a322a5ce8e14cfd2769108cf6
-    sha256: 8034b8d6ce1eee6b0f1df7512a2e13fca35d5d8e6128770eab53f452f4bdfb39
-  build: hff40170_2
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: Apache-2.0
-  license_family: Apache
-  size: 3292231
-  timestamp: 1701310066537
-- platform: linux-64
+- kind: pypi
+  name: beautifulsoup4
+  version: 4.12.3
+  url: https://files.pythonhosted.org/packages/b1/fe/e8c672695b37eecc5cbf43e1d0638d88d66ba3a44c4d321c796f4e59167f/beautifulsoup4-4.12.3-py3-none-any.whl
+  sha256: b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed
+  requires_dist:
+  - soupsieve>1.2
+  - cchardet ; extra == 'cchardet'
+  - chardet ; extra == 'chardet'
+  - charset-normalizer ; extra == 'charset-normalizer'
+  - html5lib ; extra == 'html5lib'
+  - lxml ; extra == 'lxml'
+  requires_python: '>=3.6.0'
+- kind: conda
   name: blas
   version: '2.120'
-  category: main
-  manager: conda
-  dependencies:
+  build: mkl
+  build_number: 20
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-2.120-mkl.conda
+  sha256: e2310fc7086d0af41c62e0d84f04591bf4c3b974ae80754c3650f37f07c667ab
+  md5: 9444330235a4828878cbe9c897ba0aa3
+  depends:
   - _openmp_mutex * *_llvm
   - _openmp_mutex >=4.5
   - blas-devel 3.9.0 20_linux64_mkl
@@ -926,401 +643,211 @@ package:
   - liblapack 3.9.0 20_linux64_mkl
   - liblapacke 3.9.0 20_linux64_mkl
   - llvm-openmp >=17.0.5
-  url: https://conda.anaconda.org/conda-forge/linux-64/blas-2.120-mkl.conda
-  hash:
-    md5: 9444330235a4828878cbe9c897ba0aa3
-    sha256: e2310fc7086d0af41c62e0d84f04591bf4c3b974ae80754c3650f37f07c667ab
-  build: mkl
   arch: x86_64
-  subdir: linux-64
-  build_number: 20
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 14437
   timestamp: 1700568569382
-- platform: linux-64
+- kind: conda
   name: blas-devel
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
+  build: 20_linux64_mkl
+  build_number: 20
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-20_linux64_mkl.conda
+  sha256: 74a99c20b857a01c0e1bdb00c2aec4696cf895451278d9e24171b3eed7ba1d68
+  md5: 079d50df2338a3d47522d7e84c3dfbf6
+  depends:
   - libblas 3.9.0 20_linux64_mkl
   - libcblas 3.9.0 20_linux64_mkl
   - liblapack 3.9.0 20_linux64_mkl
   - liblapacke 3.9.0 20_linux64_mkl
   - mkl >=2023.2.0,<2024.0a0
   - mkl-devel 2023.2.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.9.0-20_linux64_mkl.conda
-  hash:
-    md5: 079d50df2338a3d47522d7e84c3dfbf6
-    sha256: 74a99c20b857a01c0e1bdb00c2aec4696cf895451278d9e24171b3eed7ba1d68
-  build: 20_linux64_mkl
   arch: x86_64
-  subdir: linux-64
-  build_number: 20
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 14235
   timestamp: 1700568448283
-- platform: linux-64
+- kind: conda
   name: blinker
   version: 1.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 550da20b2c2e38be9cc44bb819fda5d5
-    sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
+  sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
+  md5: 550da20b2c2e38be9cc44bb819fda5d5
+  depends:
+  - python >=3.8
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/blinker
   size: 17886
   timestamp: 1698890303249
-- platform: osx-arm64
-  name: blinker
-  version: 1.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 550da20b2c2e38be9cc44bb819fda5d5
-    sha256: c8d72c2af4f57898dfd5e4c62ae67f7fea1490a37c8b6855460a170d61591177
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 17886
-  timestamp: 1698890303249
-- platform: linux-64
-  name: brotli
-  version: 1.0.9
-  category: main
-  manager: conda
-  dependencies:
-  - brotli-bin 1.0.9 h166bdaf_9
-  - libbrotlidec 1.0.9 h166bdaf_9
-  - libbrotlienc 1.0.9 h166bdaf_9
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_9.conda
-  hash:
-    md5: 4601544b4982ba1861fa9b9c607b2c06
-    sha256: 2357d205931912def55df0dc53573361156b27856f9bf359d464da162812ec1f
-  build: h166bdaf_9
-  arch: x86_64
-  subdir: linux-64
-  build_number: 9
-  license: MIT
-  license_family: MIT
-  size: 20065
-  timestamp: 1687884291946
-- platform: osx-arm64
-  name: brotli
-  version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - brotli-bin 1.1.0 hb547adb_1
-  - libbrotlidec 1.1.0 hb547adb_1
-  - libbrotlienc 1.1.0 hb547adb_1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hb547adb_1.conda
-  hash:
-    md5: a33aa58d448cbc054f887e39dd1dfaea
-    sha256: 62d1587deab752fcee07adc371eb20fcadc09f72c0c85399c22b637ca858020f
-  build: hb547adb_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 19506
-  timestamp: 1695990588610
-- platform: linux-64
-  name: brotli-bin
-  version: 1.0.9
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlidec 1.0.9 h166bdaf_9
-  - libbrotlienc 1.0.9 h166bdaf_9
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_9.conda
-  hash:
-    md5: d47dee1856d9cb955b8076eeff304a5b
-    sha256: 1c128f136a59ee2fa47d7fbd9b6fc8afa8460d340e4ae0e6f5419ebbd7539a10
-  build: h166bdaf_9
-  arch: x86_64
-  subdir: linux-64
-  build_number: 9
-  license: MIT
-  license_family: MIT
-  size: 20361
-  timestamp: 1687884277426
-- platform: osx-arm64
-  name: brotli-bin
-  version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlidec 1.1.0 hb547adb_1
-  - libbrotlienc 1.1.0 hb547adb_1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hb547adb_1.conda
-  hash:
-    md5: 990d04f8c017b1b77103f9a7730a5f12
-    sha256: 8fbfc2834606292016f2faffac67deea4c5cdbc21a61169f0b355e1600105a24
-  build: hb547adb_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 17001
-  timestamp: 1695990551239
-- platform: linux-64
+- kind: conda
   name: brotli-python
-  version: 1.0.9
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.1.0
+  build: py39h3d6467e_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py39h3d6467e_1.conda
+  sha256: e22afb19527a93da24c1108c3e91532811f9c3df64a9473989faf332c98af082
+  md5: c48418c8b35f1d59ae9ae1174812b40a
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.0.9-py310hd8f1fbe_9.conda
-  hash:
-    md5: e2047ad2af52c01845f58b580c6cbd5c
-    sha256: a4984cb906910850ae979387f0ac4e2623e0a3c8139bc67eb1fff0403bf8388b
-  build: py310hd8f1fbe_9
-  arch: x86_64
-  subdir: linux-64
-  build_number: 9
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   constrains:
-  - libbrotlicommon 1.0.9 h166bdaf_9
+  - libbrotlicommon 1.1.0 hd590300_1
   license: MIT
   license_family: MIT
-  size: 326479
-  timestamp: 1687884330581
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/brotli
+  size: 350065
+  timestamp: 1695990113673
+- kind: conda
   name: brotli-python
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py310h1253130_1.conda
-  hash:
-    md5: 26fab7f65a80fff9f402ec3b7860b88a
-    sha256: dab21e18c0275bfd93a09b751096998485677ed17c2e2d08298bc5b43c10bee1
-  build: py310h1253130_1
-  arch: aarch64
-  subdir: osx-arm64
+  build: py39hb198ff7_1
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py39hb198ff7_1.conda
+  sha256: 014639c1f57be1dadf7b5c17e53df562e7e6bab71d3435fdd5bd56213dece9df
+  md5: ddf01dd9a743bd3ec9cf829d18bb8002
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
   constrains:
   - libbrotlicommon 1.1.0 hb547adb_1
   license: MIT
   license_family: MIT
-  size: 344275
-  timestamp: 1695990848681
-- platform: linux-64
+  purls:
+  - pkg:pypi/brotli
+  size: 344364
+  timestamp: 1695991093404
+- kind: conda
   name: bzip2
   version: 1.0.8
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
-  hash:
-    md5: 69b8b6202a07720f448be700e300ccf4
-    sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
-  build: hd590300_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 254228
-  timestamp: 1699279927352
-- platform: osx-arm64
-  name: bzip2
-  version: 1.0.8
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
-  hash:
-    md5: 1bbc659ca658bfd49a481b5ef7a0f40f
-    sha256: bfa84296a638bea78a8bb29abc493ee95f2a0218775642474a840411b950fe5f
   build: h93a5062_5
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
+  sha256: bfa84296a638bea78a8bb29abc493ee95f2a0218775642474a840411b950fe5f
+  md5: 1bbc659ca658bfd49a481b5ef7a0f40f
+  arch: aarch64
+  platform: osx
   license: bzip2-1.0.6
   license_family: BSD
   size: 122325
   timestamp: 1699280294368
-- platform: linux-64
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: hd590300_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
+  sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
+  md5: 69b8b6202a07720f448be700e300ccf4
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 254228
+  timestamp: 1699279927352
+- kind: conda
   name: c-ares
   version: 1.23.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.23.0-hd590300_0.conda
-  hash:
-    md5: d459949bc10f64dee1595c176c2e6291
-    sha256: 6b0eee827bade11c2964a05867499a50ad2a9d1b14dfe18fb867a3bc9357f56f
   build: hd590300_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.23.0-hd590300_0.conda
+  sha256: 6b0eee827bade11c2964a05867499a50ad2a9d1b14dfe18fb867a3bc9357f56f
+  md5: d459949bc10f64dee1595c176c2e6291
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   size: 153627
   timestamp: 1701382098569
-- platform: osx-arm64
+- kind: conda
   name: c-ares
-  version: 1.23.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.23.0-h93a5062_0.conda
-  hash:
-    md5: b187f2b99e52905042d661f824666964
-    sha256: de5385280dcad805428068adb1f4a7eb1e6ec8987e2f25c4ff5766e3fec3b4a2
+  version: 1.28.1
   build: h93a5062_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.28.1-h93a5062_0.conda
+  sha256: 2fc553d7a75e912efbdd6b82cd7916cc9cb2773e6cd873b77e02d631dd7be698
+  md5: 04f776a6139f7eafc2f38668570eb7db
   license: MIT
   license_family: MIT
-  size: 136858
-  timestamp: 1701382321331
-- platform: linux-64
+  size: 150488
+  timestamp: 1711819630164
+- kind: conda
   name: ca-certificates
   version: 2023.11.17
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
-  hash:
-    md5: 01ffc8d36f9eba0ce0b3c1955fa780ee
-    sha256: fb4b9f4b7d885002db0b93e22f44b5b03791ef3d4efdc9d0662185a0faafd6b6
   build: hbcca054_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.11.17-hbcca054_0.conda
+  sha256: fb4b9f4b7d885002db0b93e22f44b5b03791ef3d4efdc9d0662185a0faafd6b6
+  md5: 01ffc8d36f9eba0ce0b3c1955fa780ee
+  arch: x86_64
+  platform: linux
   license: ISC
   size: 154117
   timestamp: 1700280881924
-- platform: osx-arm64
+- kind: conda
   name: ca-certificates
   version: 2023.11.17
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.11.17-hf0a4a13_0.conda
-  hash:
-    md5: c01da7c77cfcba2107174e25c1d47384
-    sha256: 75f4762a55f7e9453a603c967d549bfa0a7a9669d502d103cb6fbf8c86d993c6
   build: hf0a4a13_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.11.17-hf0a4a13_0.conda
+  sha256: 75f4762a55f7e9453a603c967d549bfa0a7a9669d502d103cb6fbf8c86d993c6
+  md5: c01da7c77cfcba2107174e25c1d47384
+  arch: aarch64
+  platform: osx
   license: ISC
   size: 154444
   timestamp: 1700280972188
-- platform: linux-64
+- kind: conda
   name: cachetools
   version: 5.3.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 185cc1bf1d5af90020292888a3c7eb5d
-    sha256: cb8a6688d5650e4546a5f3c5b825bfe3c82594f1f588a93817f1bdb23e74baad
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 14739
-  timestamp: 1698197442391
-- platform: osx-arm64
-  name: cachetools
-  version: 5.3.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 185cc1bf1d5af90020292888a3c7eb5d
-    sha256: cb8a6688d5650e4546a5f3c5b825bfe3c82594f1f588a93817f1bdb23e74baad
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.2-pyhd8ed1ab_0.conda
+  sha256: cb8a6688d5650e4546a5f3c5b825bfe3c82594f1f588a93817f1bdb23e74baad
+  md5: 185cc1bf1d5af90020292888a3c7eb5d
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/cachetools
   size: 14739
   timestamp: 1698197442391
-- platform: linux-64
-  name: cairo
-  version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
-  - fontconfig >=2.13.96,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=70.1,<71.0a0
-  - libgcc-ng >=12
-  - libglib >=2.72.1,<3.0a0
-  - libpng >=1.6.38,<1.7.0a0
-  - libxcb >=1.13,<1.14.0a0
-  - libzlib >=1.2.12,<1.3.0a0
-  - pixman >=0.40.0,<1.0a0
-  - xorg-libice
-  - xorg-libsm
-  - xorg-libx11
-  - xorg-libxext
-  - xorg-libxrender
-  - zlib >=1.2.12,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-ha61ee94_1014.tar.bz2
-  hash:
-    md5: d1a88f3ed5b52e1024b80d4bcd26a7a0
-    sha256: f062cf56e6e50d3ad4b425ebb3765ca9138c6ebc52e6a42d1377de8bc8d954f6
-  build: ha61ee94_1014
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1014
-  license: LGPL-2.1-only or MPL-1.1
-  size: 1576122
-  timestamp: 1663568213559
-- platform: osx-arm64
+- kind: conda
   name: cairo
   version: 1.18.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hd1e100b_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
+  sha256: 599f8820553b3a3405706d9cad390ac199e24515a0a82c87153c9b5b5fdba3b8
+  md5: 3fa6eebabb77f65e82f86b72b95482db
+  depends:
   - __osx >=10.9
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
@@ -1332,354 +859,270 @@ package:
   - libzlib >=1.2.13,<1.3.0a0
   - pixman >=0.42.2,<1.0a0
   - zlib
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
-  hash:
-    md5: 3fa6eebabb77f65e82f86b72b95482db
-    sha256: 599f8820553b3a3405706d9cad390ac199e24515a0a82c87153c9b5b5fdba3b8
-  build: hd1e100b_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: LGPL-2.1-only or MPL-1.1
   size: 897919
   timestamp: 1697028755150
-- platform: linux-64
+- kind: conda
   name: certifi
   version: 2023.11.17
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2011bcf45376341dd1d690263fdbc789
-    sha256: afa22b77128a812cb57bc707c297d926561bd225a3d9dd74205d87a3b2d14a96
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: ISC
-  noarch: python
-  size: 158939
-  timestamp: 1700303562512
-- platform: osx-arm64
-  name: certifi
-  version: 2023.11.17
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2011bcf45376341dd1d690263fdbc789
-    sha256: afa22b77128a812cb57bc707c297d926561bd225a3d9dd74205d87a3b2d14a96
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
-  license: ISC
   noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.11.17-pyhd8ed1ab_0.conda
+  sha256: afa22b77128a812cb57bc707c297d926561bd225a3d9dd74205d87a3b2d14a96
+  md5: 2011bcf45376341dd1d690263fdbc789
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
+  license: ISC
+  purls:
+  - pkg:pypi/certifi
   size: 158939
   timestamp: 1700303562512
-- platform: linux-64
+- kind: conda
   name: cffi
   version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py39h7a31438_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py39h7a31438_0.conda
+  sha256: 1536a2ca65caaf568bbdfe75aff8e12cb0e0507587b25af3b532a8bd22cb3ddb
+  md5: ac992767d7f8ed2cb27e71e78f0fb2d7
+  depends:
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - pycparser
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
-  hash:
-    md5: 45846a970e71ac98fd327da5d40a0a2c
-    sha256: 007e7f69ab45553b7bf11f2c1b8d3f3a13fd42997266a0d57795f41c7d38df36
-  build: py310h2fee648_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   license: MIT
   license_family: MIT
-  size: 241339
-  timestamp: 1696001848492
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/cffi
+  size: 239801
+  timestamp: 1696001890928
+- kind: conda
   name: cffi
   version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py39he153c15_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py39he153c15_0.conda
+  sha256: 2766a3bec7747d14fe646b2a3ec4ba508495ea8b0a434213189d3e4d20e24e4b
+  md5: 2be3a21503b84cbd74dd1c11f36c4a3c
+  depends:
   - libffi >=3.4,<4.0a0
   - pycparser
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py310hdcd7c05_0.conda
-  hash:
-    md5: 8855823d908004e4d3b4fd4218795ad2
-    sha256: 4edab3f1f855554e10950efe064b75138943812af829a764f9b570d1a7189d15
-  build: py310hdcd7c05_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
   license: MIT
   license_family: MIT
-  size: 232227
-  timestamp: 1696002085787
-- platform: linux-64
+  purls:
+  - pkg:pypi/cffi
+  size: 231790
+  timestamp: 1696002104149
+- kind: conda
   name: charset-normalizer
   version: 3.3.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f4a9e3fcff3f6356ae99244a014da6a
-    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+  sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+  md5: 7f4a9e3fcff3f6356ae99244a014da6a
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/charset-normalizer
   size: 46597
   timestamp: 1698833765762
-- platform: osx-arm64
-  name: charset-normalizer
-  version: 3.3.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f4a9e3fcff3f6356ae99244a014da6a
-    sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 46597
-  timestamp: 1698833765762
-- platform: linux-64
+- kind: conda
   name: click
   version: 8.1.7
-  category: main
-  manager: conda
-  dependencies:
+  build: unix_pyh707e725_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
+  sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
+  md5: f3ad426304898027fc619827ff428eca
+  depends:
   - __unix
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
-  hash:
-    md5: f3ad426304898027fc619827ff428eca
-    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
-  build: unix_pyh707e725_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/click
   size: 84437
   timestamp: 1692311973840
-- platform: osx-arm64
-  name: click
-  version: 8.1.7
-  category: main
-  manager: conda
-  dependencies:
-  - __unix
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
-  hash:
-    md5: f3ad426304898027fc619827ff428eca
-    sha256: f0016cbab6ac4138a429e28dbcb904a90305b34b3fe41a9b89d697c90401caec
-  build: unix_pyh707e725_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 84437
-  timestamp: 1692311973840
-- platform: linux-64
+- kind: conda
   name: colorama
   version: 0.4.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/colorama
   size: 25170
   timestamp: 1666700778190
-- platform: osx-arm64
-  name: colorama
-  version: 0.4.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3faab06a954c2a04039983f2c4a50d99
-    sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 25170
-  timestamp: 1666700778190
-- platform: linux-64
+- kind: pypi
+  name: comm
+  version: 0.2.2
+  url: https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl
+  sha256: e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3
+  requires_dist:
+  - traitlets>=4
+  - pytest ; extra == 'test'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: configargparse
+  version: '1.7'
+  url: https://files.pythonhosted.org/packages/6f/b3/b4ac838711fd74a2b4e6f746703cf9dd2cf5462d17dac07e349234e21b97/ConfigArgParse-1.7-py3-none-any.whl
+  sha256: d249da6591465c6c26df64a9f73d2536e743be2f244eb3ebe61114af2f94f86b
+  requires_dist:
+  - mock ; extra == 'test'
+  - pyyaml ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pyyaml ; extra == 'yaml'
+  requires_python: '>=3.5'
+- kind: pypi
   name: contourpy
-  version: 1.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - numpy >=1.20,<2
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.0-py310hd41b1e2_0.conda
-  hash:
-    md5: 85d2aaa7af046528d339da1e813c3a9f
-    sha256: 73dd7868bfd98fa9e4d2cc524687b5c5c8f9d427d4e521875aacfe152eae4715
-  build: py310hd41b1e2_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 238877
-  timestamp: 1699041552962
-- platform: osx-arm64
+  version: 1.2.1
+  url: https://files.pythonhosted.org/packages/1e/f5/8a0e688c3a6098a358fa359da6a09a7b9afd8f3f6c9b83e9898c29e87b95/contourpy-1.2.1-cp39-cp39-macosx_11_0_arm64.whl
+  sha256: 1d59e739ab0e3520e62a26c60707cc3ab0365d2f8fecea74bfe4de72dc56388f
+  requires_dist:
+  - numpy>=1.20
+  - furo ; extra == 'docs'
+  - sphinx>=7.2 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - bokeh ; extra == 'bokeh'
+  - selenium ; extra == 'bokeh'
+  - contourpy[bokeh,docs] ; extra == 'mypy'
+  - docutils-stubs ; extra == 'mypy'
+  - mypy==1.8.0 ; extra == 'mypy'
+  - types-pillow ; extra == 'mypy'
+  - contourpy[test-no-images] ; extra == 'test'
+  - matplotlib ; extra == 'test'
+  - pillow ; extra == 'test'
+  - pytest ; extra == 'test-no-images'
+  - pytest-cov ; extra == 'test-no-images'
+  - pytest-xdist ; extra == 'test-no-images'
+  - wurlitzer ; extra == 'test-no-images'
+  requires_python: '>=3.9'
+- kind: pypi
   name: contourpy
-  version: 1.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - numpy >=1.20,<2
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.2.0-py310hd137fd4_0.conda
-  hash:
-    md5: cfb55213e1fc0a58c3cfdb0544ecb80d
-    sha256: c82dccf0ef3df3a894f6a11469b10107b29d4e7b678cb409224fbaf954a1716d
-  build: py310hd137fd4_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 223917
-  timestamp: 1699041828998
-- platform: linux-64
+  version: 1.2.1
+  url: https://files.pythonhosted.org/packages/31/a2/2f12e3a6e45935ff694654b710961b03310b0e1ec997ee9f416d3c873f87/contourpy-1.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: e1d59258c3c67c865435d8fbeb35f8c59b8bef3d6f46c1f29f6123556af28445
+  requires_dist:
+  - numpy>=1.20
+  - furo ; extra == 'docs'
+  - sphinx>=7.2 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - bokeh ; extra == 'bokeh'
+  - selenium ; extra == 'bokeh'
+  - contourpy[bokeh,docs] ; extra == 'mypy'
+  - docutils-stubs ; extra == 'mypy'
+  - mypy==1.8.0 ; extra == 'mypy'
+  - types-pillow ; extra == 'mypy'
+  - contourpy[test-no-images] ; extra == 'test'
+  - matplotlib ; extra == 'test'
+  - pillow ; extra == 'test'
+  - pytest ; extra == 'test-no-images'
+  - pytest-cov ; extra == 'test-no-images'
+  - pytest-xdist ; extra == 'test-no-images'
+  - wurlitzer ; extra == 'test-no-images'
+  requires_python: '>=3.9'
+- kind: conda
   name: cryptography
-  version: 41.0.7
-  category: main
-  manager: conda
-  dependencies:
+  version: 42.0.1
+  build: py39he6105cc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.1-py39he6105cc_0.conda
+  sha256: d851d6c7a781a4bedb80ff5a6b4ef3e31bfe5d546179c31600e626b2e18964aa
+  md5: 8b8918aae6224d2be47a07b3cab4bd3d
+  depends:
   - cffi >=1.12
   - libgcc-ng >=12
   - openssl >=3.1.4,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-41.0.7-py310hb8475ec_1.conda
-  hash:
-    md5: 8a84d96d106767c08d6154ed5c8aae2c
-    sha256: 493feafc2492e841d361affb0bba2e29ab41d73b8db2d58c5abdfd4ccf1d29ad
-  build: py310hb8475ec_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
-  size: 1980600
-  timestamp: 1701563433239
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/cryptography
+  size: 1991833
+  timestamp: 1706207557341
+- kind: conda
   name: cryptography
-  version: 41.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - cffi >=1.12
-  - openssl >=3.1.4,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-41.0.7-py310h4c55245_1.conda
-  hash:
-    md5: 9d2f02b43aaceb00fbe294ce9e9646c6
-    sha256: 85ce5e6db3093fea6bb45c28d783db002339cc56b578789d6141b136a4266a59
-  build: py310h4c55245_1
-  arch: aarch64
+  version: 42.0.2
+  build: py39hbc7c26c_0
   subdir: osx-arm64
-  build_number: 1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-42.0.2-py39hbc7c26c_0.conda
+  sha256: c640e64c1c9bedc29cdfa37f98e7cda48495304383656d9ea76e4fa74991004b
+  md5: eb27dd67c18dfbbaae35bc11985881ed
+  depends:
+  - cffi >=1.12
+  - openssl >=3.1.5,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - __osx >=11.0
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
-  size: 1200542
-  timestamp: 1701563810375
-- platform: linux-64
+  purls:
+  - pkg:pypi/cryptography
+  size: 1241425
+  timestamp: 1706659159101
+- kind: conda
   name: cuda-cudart
   version: 11.7.99
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-11.7.99-0.tar.bz2
-  hash:
-    md5: 79859ac9109109826d77e5e2bbbe18b5
-    sha256: e75a62cf7cebdd7773c8deb148e06030714ed4c5fb6c8dc3f7792bb7b6e8ce6c
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cudart-11.7.99-0.tar.bz2
+  sha256: e75a62cf7cebdd7773c8deb148e06030714ed4c5fb6c8dc3f7792bb7b6e8ce6c
+  md5: 79859ac9109109826d77e5e2bbbe18b5
+  arch: x86_64
+  platform: linux
   size: 198566
   timestamp: 1654740997113
-- platform: linux-64
+- kind: conda
   name: cuda-cupti
   version: 11.7.101
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cupti-11.7.101-0.tar.bz2
-  hash:
-    md5: 099e29408a247a0a50bc976dc5e716b0
-    sha256: 11d6d31fec7f54a9390d167741da51c05fa4fa31ce64eac250d069570c06cf2c
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-cupti-11.7.101-0.tar.bz2
+  sha256: 11d6d31fec7f54a9390d167741da51c05fa4fa31ce64eac250d069570c06cf2c
+  md5: 099e29408a247a0a50bc976dc5e716b0
+  arch: x86_64
+  platform: linux
   size: 23995104
   timestamp: 1657656737157
-- platform: linux-64
+- kind: conda
   name: cuda-libraries
   version: 11.7.1
-  category: main
-  manager: conda
-  dependencies:
+  build: '0'
+  subdir: linux-64
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-11.7.1-0.tar.bz2
+  sha256: 0e28c0d2f6462437dfe21c3a8e17351adc76f9882a5f1e8be8dce3d6bf8f19a9
+  md5: 6fc99cc9d2e7d6d2da1c10c5e140ab8c
+  depends:
   - cuda-cudart >=11.7.99
   - cuda-nvrtc >=11.7.99
   - libcublas >=11.10.3.66
@@ -1690,269 +1133,232 @@ package:
   - libcusparse >=11.7.4.91
   - libnpp >=11.7.4.75
   - libnvjpeg >=11.8.0.2
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-libraries-11.7.1-0.tar.bz2
-  hash:
-    md5: 6fc99cc9d2e7d6d2da1c10c5e140ab8c
-    sha256: 0e28c0d2f6462437dfe21c3a8e17351adc76f9882a5f1e8be8dce3d6bf8f19a9
-  build: '0'
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   size: 1531
   timestamp: 1659086449327
-- platform: linux-64
+- kind: conda
   name: cuda-nvrtc
   version: 11.7.99
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-11.7.99-0.tar.bz2
-  hash:
-    md5: f56ebbd9aa130d0fae45079d8bf76617
-    sha256: 76eeb17cbdc9767e85fd3e20a8e06f1999aa190fc042265da4eabf550aa12ac9
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvrtc-11.7.99-0.tar.bz2
+  sha256: 76eeb17cbdc9767e85fd3e20a8e06f1999aa190fc042265da4eabf550aa12ac9
+  md5: f56ebbd9aa130d0fae45079d8bf76617
+  arch: x86_64
+  platform: linux
   size: 18143447
   timestamp: 1654742628173
-- platform: linux-64
+- kind: conda
   name: cuda-nvtx
   version: 11.7.91
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvtx-11.7.91-0.tar.bz2
-  hash:
-    md5: 87381e82875d3b341e2d48a5c4d26e2b
-    sha256: 9458059b0f5e1d28a09d9cb32e441f01c050e2d92630020011fa009b98e0f445
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-nvtx-11.7.91-0.tar.bz2
+  sha256: 9458059b0f5e1d28a09d9cb32e441f01c050e2d92630020011fa009b98e0f445
+  md5: 87381e82875d3b341e2d48a5c4d26e2b
+  arch: x86_64
+  platform: linux
   size: 58340
   timestamp: 1653017324477
-- platform: linux-64
+- kind: conda
   name: cuda-runtime
   version: 11.7.1
-  category: main
-  manager: conda
-  dependencies:
-  - cuda-libraries >=11.7.1
-  url: https://conda.anaconda.org/nvidia/linux-64/cuda-runtime-11.7.1-0.tar.bz2
-  hash:
-    md5: e88cf61af312d2621a0224d431be511b
-    sha256: 99fccfabca4fda89d71fb92a42b77052f2b43e8ad9207bca1f88c3c518be3f82
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/cuda-runtime-11.7.1-0.tar.bz2
+  sha256: 99fccfabca4fda89d71fb92a42b77052f2b43e8ad9207bca1f88c3c518be3f82
+  md5: e88cf61af312d2621a0224d431be511b
+  depends:
+  - cuda-libraries >=11.7.1
+  arch: x86_64
+  platform: linux
   size: 1428
   timestamp: 1659086511109
-- platform: linux-64
+- kind: pypi
   name: cycler
   version: 0.12.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 13458
-  timestamp: 1696677888423
-- platform: osx-arm64
-  name: cycler
-  version: 0.12.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 13458
-  timestamp: 1696677888423
-- platform: linux-64
-  name: dataclasses
-  version: '0.8'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2
-  hash:
-    md5: a362b2124b06aad102e2ee4581acee7d
-    sha256: 63a83e62e0939bc1ab32de4ec736f6403084198c4639638b354a352113809c92
-  build: pyhc8e2a94_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 9870
-  timestamp: 1628958582931
-- platform: osx-arm64
-  name: dataclasses
-  version: '0.8'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/dataclasses-0.8-pyhc8e2a94_3.tar.bz2
-  hash:
-    md5: a362b2124b06aad102e2ee4581acee7d
-    sha256: 63a83e62e0939bc1ab32de4ec736f6403084198c4639638b354a352113809c92
-  build: pyhc8e2a94_3
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 3
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 9870
-  timestamp: 1628958582931
-- platform: osx-arm64
+  url: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+  sha256: 85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30
+  requires_dist:
+  - ipython ; extra == 'docs'
+  - matplotlib ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-xdist ; extra == 'tests'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: dash
+  version: 2.17.0
+  url: https://files.pythonhosted.org/packages/63/22/bc266b167111e70a2da940e78b78d22fea5b1ee32b512ed0789bd6cc2a9f/dash-2.17.0-py3-none-any.whl
+  sha256: 2421569023b2cd46ea2d4b2c14fe72c71b7436527a3102219b2265fa361e7c67
+  requires_dist:
+  - flask<3.1,>=1.0.4
+  - werkzeug<3.1
+  - plotly>=5.0.0
+  - dash-html-components==2.0.0
+  - dash-core-components==2.0.0
+  - dash-table==5.0.0
+  - importlib-metadata
+  - typing-extensions>=4.1.1
+  - requests
+  - retrying
+  - nest-asyncio
+  - setuptools
+  - redis>=3.5.3 ; extra == 'celery'
+  - celery[redis]>=5.1.2 ; extra == 'celery'
+  - black==22.3.0 ; extra == 'ci'
+  - dash-flow-example==0.0.5 ; extra == 'ci'
+  - dash-dangerously-set-inner-html ; extra == 'ci'
+  - flake8==7.0.0 ; extra == 'ci'
+  - flaky==3.8.1 ; extra == 'ci'
+  - flask-talisman==1.0.0 ; extra == 'ci'
+  - mimesis<=11.1.0 ; extra == 'ci'
+  - mock==4.0.3 ; extra == 'ci'
+  - numpy<=1.26.3 ; extra == 'ci'
+  - orjson==3.9.12 ; extra == 'ci'
+  - openpyxl ; extra == 'ci'
+  - pandas>=1.4.0 ; extra == 'ci'
+  - pyarrow ; extra == 'ci'
+  - pylint==3.0.3 ; extra == 'ci'
+  - pytest-mock ; extra == 'ci'
+  - pytest-sugar==0.9.6 ; extra == 'ci'
+  - pyzmq==25.1.2 ; extra == 'ci'
+  - xlrd>=2.0.1 ; extra == 'ci'
+  - pytest-rerunfailures ; extra == 'ci'
+  - jupyterlab<4.0.0 ; extra == 'ci'
+  - flask-compress ; extra == 'compress'
+  - coloredlogs>=15.0.1 ; extra == 'dev'
+  - fire>=0.4.0 ; extra == 'dev'
+  - pyyaml>=5.4.1 ; extra == 'dev'
+  - diskcache>=5.2.1 ; extra == 'diskcache'
+  - multiprocess>=0.70.12 ; extra == 'diskcache'
+  - psutil>=5.8.0 ; extra == 'diskcache'
+  - beautifulsoup4>=4.8.2 ; extra == 'testing'
+  - lxml>=4.6.2 ; extra == 'testing'
+  - percy>=2.0.2 ; extra == 'testing'
+  - pytest>=6.0.2 ; extra == 'testing'
+  - requests[security]>=2.21.0 ; extra == 'testing'
+  - selenium<=4.2.0,>=3.141.0 ; extra == 'testing'
+  - waitress>=1.4.4 ; extra == 'testing'
+  - multiprocess>=0.70.12 ; extra == 'testing'
+  - psutil>=5.8.0 ; extra == 'testing'
+  - dash-testing-stub>=0.0.2 ; extra == 'testing'
+  - cryptography<3.4 ; python_version < '3.7' and extra == 'testing'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: dash-core-components
+  version: 2.0.0
+  url: https://files.pythonhosted.org/packages/00/9e/a29f726e84e531a36d56cff187e61d8c96d2cc253c5bcef9a7695acb7e6a/dash_core_components-2.0.0-py3-none-any.whl
+  sha256: 52b8e8cce13b18d0802ee3acbc5e888cb1248a04968f962d63d070400af2e346
+- kind: pypi
+  name: dash-html-components
+  version: 2.0.0
+  url: https://files.pythonhosted.org/packages/75/65/1b16b853844ef59b2742a7de74a598f376ac0ab581f0dcc34db294e5c90e/dash_html_components-2.0.0-py3-none-any.whl
+  sha256: b42cc903713c9706af03b3f2548bda4be7307a7cf89b7d6eae3da872717d1b63
+- kind: pypi
+  name: dash-table
+  version: 5.0.0
+  url: https://files.pythonhosted.org/packages/da/ce/43f77dc8e7bbad02a9f88d07bf794eaf68359df756a28bb9f2f78e255bb1/dash_table-5.0.0-py3-none-any.whl
+  sha256: 19036fa352bb1c11baf38068ec62d172f0515f73ca3276c79dee49b95ddc16c9
+- kind: conda
   name: dav1d
   version: 1.2.1
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
-  hash:
-    md5: 5a74cdee497e6b65173e10d94582fae6
-    sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
   build: hb547adb_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+  sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
+  md5: 5a74cdee497e6b65173e10d94582fae6
+  arch: aarch64
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 316394
   timestamp: 1685695959391
-- platform: linux-64
-  name: dbus
-  version: 1.13.6
-  category: main
-  manager: conda
-  dependencies:
-  - expat >=2.4.2,<3.0a0
-  - libgcc-ng >=9.4.0
-  - libglib >=2.70.2,<3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
-  hash:
-    md5: ecfff944ba3960ecb334b9a2663d708d
-    sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
-  build: h5008d03_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 618596
-  timestamp: 1640112124844
-- platform: linux-64
+- kind: pypi
+  name: decorator
+  version: 4.4.2
+  url: https://files.pythonhosted.org/packages/ed/1b/72a1821152d07cf1d8b6fce298aeb06a7eb90f4d6d41acec9861e7cc6df0/decorator-4.4.2-py2.py3-none-any.whl
+  sha256: 41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760
+  requires_python: '>=2.6,!=3.0.*,!=3.1.*'
+- kind: pypi
+  name: efficientnet-pytorch
+  version: 0.7.1
+  url: https://files.pythonhosted.org/packages/2e/a0/dd40b50aebf0028054b6b35062948da01123d7be38d08b6b1e5435df6363/efficientnet_pytorch-0.7.1.tar.gz
+  sha256: 00b9b261effce59d2d47aae2ad238c29a2a65175470f41ada7ecac439b7c1ee1
+  requires_dist:
+  - torch
+  requires_python: '>=3.5.0'
+- kind: pypi
   name: einops
-  version: 0.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/einops-0.7.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 1641890c9375ddb22381f3eb9ac157df
-    sha256: cc08bb969a4458b7afd48e7ba8151c95b48f1c315d3567644ed4a97ee2987247
-  build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 40360
-  timestamp: 1696154415252
-- platform: osx-arm64
-  name: einops
-  version: 0.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/einops-0.7.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: 1641890c9375ddb22381f3eb9ac157df
-    sha256: cc08bb969a4458b7afd48e7ba8151c95b48f1c315d3567644ed4a97ee2987247
-  build: pyhd8ed1ab_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 40360
-  timestamp: 1696154415252
-- platform: linux-64
+  version: 0.8.0
+  url: https://files.pythonhosted.org/packages/44/5a/f0b9ad6c0a9017e62d4735daaeb11ba3b6c009d69a26141b258cd37b5588/einops-0.8.0-py3-none-any.whl
+  sha256: 9572fb63046264a862693b0a87088af3bdc8c068fde03de63453cbbde245465f
+  requires_python: '>=3.8'
+- kind: pypi
+  name: exceptiongroup
+  version: 1.2.1
+  url: https://files.pythonhosted.org/packages/01/90/79fe92dd413a9cab314ef5c591b5aa9b9ba787ae4cadab75055b0ae00b33/exceptiongroup-1.2.1-py3-none-any.whl
+  sha256: 5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad
+  requires_dist:
+  - pytest>=6 ; extra == 'test'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: executing
+  version: 2.0.1
+  url: https://files.pythonhosted.org/packages/80/03/6ea8b1b2a5ab40a7a60dc464d3daa7aa546e0a74d74a9f8ff551ea7905db/executing-2.0.1-py2.py3-none-any.whl
+  sha256: eac49ca94516ccc753f9fb5ce82603156e590b27525a8bc32cce8ae302eb61bc
+  requires_dist:
+  - asttokens>=2.1.0 ; extra == 'tests'
+  - ipython ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - coverage ; extra == 'tests'
+  - coverage-enable-subprocess ; extra == 'tests'
+  - littleutils ; extra == 'tests'
+  - rich ; python_version >= '3.11' and extra == 'tests'
+  requires_python: '>=3.5'
+- kind: conda
   name: expat
   version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - libexpat 2.5.0 hcb278e6_1
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
-  hash:
-    md5: 8b9b5aca60558d02ddaa09d599e55920
-    sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
-  build: hcb278e6_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 136778
-  timestamp: 1680190541750
-- platform: osx-arm64
-  name: expat
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - libexpat 2.5.0 hb7217d7_1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
-  hash:
-    md5: 624fa0dd6fdeaa650b71a62296fdfedf
-    sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
   build: hb7217d7_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+  sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
+  md5: 624fa0dd6fdeaa650b71a62296fdfedf
+  depends:
+  - libexpat 2.5.0 hb7217d7_1
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 117851
   timestamp: 1680190940654
-- platform: linux-64
+- kind: pypi
+  name: fastjsonschema
+  version: 2.19.1
+  url: https://files.pythonhosted.org/packages/9c/b9/79691036d4a8f9857e74d1728b23f34f583b81350a27492edda58d5604e1/fastjsonschema-2.19.1-py3-none-any.whl
+  sha256: 3672b47bc94178c9f23dbb654bf47440155d4db9df5f7bc47643315f9c405cd0
+  requires_dist:
+  - colorama ; extra == 'devel'
+  - jsonschema ; extra == 'devel'
+  - json-spec ; extra == 'devel'
+  - pylint ; extra == 'devel'
+  - pytest ; extra == 'devel'
+  - pytest-benchmark ; extra == 'devel'
+  - pytest-cache ; extra == 'devel'
+  - validictory ; extra == 'devel'
+- kind: conda
   name: ffmpeg
   version: '4.3'
-  category: main
-  manager: conda
-  dependencies:
+  build: hf484d3e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/pytorch/linux-64/ffmpeg-4.3-hf484d3e_0.tar.bz2
+  sha256: 60b3e36cb36b706f5850f155bd9d3f33194a522b5ef20be46cb37dbc987a6741
+  md5: 0b0bf7c3d7e146ef91de5310bbf7a230
+  depends:
   - bzip2 >=1.0.8,<2.0a0
   - freetype >=2.10.2,<3.0a0
   - gmp >=6.1.2
@@ -1963,23 +1369,21 @@ package:
   - libstdcxx-ng >=7.3.0
   - openh264 >=2.1.0,<2.2.0a0
   - zlib >=1.2.11,<1.3.0a0
-  url: https://conda.anaconda.org/pytorch/linux-64/ffmpeg-4.3-hf484d3e_0.tar.bz2
-  hash:
-    md5: 0b0bf7c3d7e146ef91de5310bbf7a230
-    sha256: 60b3e36cb36b706f5850f155bd9d3f33194a522b5ef20be46cb37dbc987a6741
-  build: hf484d3e_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: LGPL
   size: 10426878
   timestamp: 1596130242227
-- platform: osx-arm64
+- kind: conda
   name: ffmpeg
   version: 5.1.2
-  category: main
-  manager: conda
-  dependencies:
+  build: gpl_h9861f02_112
+  build_number: 112
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-5.1.2-gpl_h9861f02_112.conda
+  sha256: be91fcf1703540a669dd4334b1875ee7f42852a3f2a2209c6a95874fe518a837
+  md5: bd236458b1f4c200e9ec9077545e342b
+  depends:
   - aom >=3.6.1,<3.7.0a0
   - bzip2 >=1.0.8,<2.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
@@ -2000,855 +1404,464 @@ package:
   - svt-av1 >=1.4.1,<1.4.2.0a0
   - x264 >=1!164.3095,<1!165
   - x265 >=3.5,<3.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-5.1.2-gpl_h9861f02_112.conda
-  hash:
-    md5: bd236458b1f4c200e9ec9077545e342b
-    sha256: be91fcf1703540a669dd4334b1875ee7f42852a3f2a2209c6a95874fe518a837
-  build: gpl_h9861f02_112
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 112
+  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL
   size: 8552010
   timestamp: 1696215008289
-- platform: linux-64
-  name: fftw
-  version: 3.3.10
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=11.4.0
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/fftw-3.3.10-nompi_hc118613_108.conda
-  hash:
-    md5: 6fa90698000b05dfe8ce6515794fe71a
-    sha256: 1952dbb3c40931fc4608e053e32cbebbdcd8f3ea5b6a050156df6dd66ad64912
-  build: nompi_hc118613_108
-  arch: x86_64
-  subdir: linux-64
-  build_number: 108
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 2019717
-  timestamp: 1686584867122
-- platform: linux-64
+- kind: pypi
   name: filelock
-  version: 3.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0c1729b74a8152fde6a38ba0a2ab9f45
-    sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Unlicense
-  noarch: python
-  size: 15605
-  timestamp: 1698715139726
-- platform: osx-arm64
-  name: filelock
-  version: 3.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0c1729b74a8152fde6a38ba0a2ab9f45
-    sha256: 4d742d91412d1f163e5399d2b50c5d479694ebcd309127abb549ca3977f89d2b
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Unlicense
-  noarch: python
-  size: 15605
-  timestamp: 1698715139726
-- platform: linux-64
+  version: 3.14.0
+  url: https://files.pythonhosted.org/packages/41/24/0b023b6537dfc9bae2c779353998e3e99ac7dfff4222fc6126650e93c3f3/filelock-3.14.0-py3-none-any.whl
+  sha256: 43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f
+  requires_dist:
+  - furo>=2023.9.10 ; extra == 'docs'
+  - sphinx-autodoc-typehints!=1.23.4,>=1.25.2 ; extra == 'docs'
+  - sphinx>=7.2.6 ; extra == 'docs'
+  - covdefaults>=2.3 ; extra == 'testing'
+  - coverage>=7.3.2 ; extra == 'testing'
+  - diff-cover>=8.0.1 ; extra == 'testing'
+  - pytest-cov>=4.1 ; extra == 'testing'
+  - pytest-mock>=3.12 ; extra == 'testing'
+  - pytest-timeout>=2.2 ; extra == 'testing'
+  - pytest>=7.4.3 ; extra == 'testing'
+  - typing-extensions>=4.8 ; python_version < '3.11' and extra == 'typing'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: flask
+  version: 3.0.3
+  url: https://files.pythonhosted.org/packages/61/80/ffe1da13ad9300f87c93af113edd0638c75138c42a0994becfacac078c06/flask-3.0.3-py3-none-any.whl
+  sha256: 34e815dfaa43340d1d15a5c3a02b8476004037eb4840b34910c6e21679d288f3
+  requires_dist:
+  - werkzeug>=3.0.0
+  - jinja2>=3.1.2
+  - itsdangerous>=2.1.2
+  - click>=8.1.3
+  - blinker>=1.6.2
+  - importlib-metadata>=3.6.0 ; python_version < '3.10'
+  - asgiref>=3.2 ; extra == 'async'
+  - python-dotenv ; extra == 'dotenv'
+  requires_python: '>=3.8'
+- kind: conda
   name: font-ttf-dejavu-sans-mono
   version: '2.37'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  hash:
-    md5: 0c96522c6bdaed4b1566d11387caaf45
-    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   build: hab24e00_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: generic
   size: 397370
   timestamp: 1566932522327
-- platform: osx-arm64
-  name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  hash:
-    md5: 0c96522c6bdaed4b1566d11387caaf45
-    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  build: hab24e00_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: generic
-  size: 397370
-  timestamp: 1566932522327
-- platform: linux-64
+- kind: conda
   name: font-ttf-inconsolata
   version: '3.000'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  hash:
-    md5: 34893075a5c9e55cdafac56607368fc6
-    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
   build: h77eed37_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  arch: aarch64
+  platform: osx
   license: OFL-1.1
   license_family: Other
-  noarch: generic
   size: 96530
   timestamp: 1620479909603
-- platform: osx-arm64
-  name: font-ttf-inconsolata
-  version: '3.000'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  hash:
-    md5: 34893075a5c9e55cdafac56607368fc6
-    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  build: h77eed37_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: OFL-1.1
-  license_family: Other
-  noarch: generic
-  size: 96530
-  timestamp: 1620479909603
-- platform: linux-64
+- kind: conda
   name: font-ttf-source-code-pro
   version: '2.038'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  hash:
-    md5: 4d59c254e01d9cde7957100457e2d5fb
-    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
   build: h77eed37_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  arch: aarch64
+  platform: osx
   license: OFL-1.1
   license_family: Other
-  noarch: generic
   size: 700814
   timestamp: 1620479612257
-- platform: osx-arm64
-  name: font-ttf-source-code-pro
-  version: '2.038'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  hash:
-    md5: 4d59c254e01d9cde7957100457e2d5fb
-    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  build: h77eed37_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: OFL-1.1
-  license_family: Other
-  noarch: generic
-  size: 700814
-  timestamp: 1620479612257
-- platform: linux-64
+- kind: conda
   name: font-ttf-ubuntu
   version: '0.83'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
-  hash:
-    md5: 6185f640c43843e5ad6fd1c5372c3f80
-    sha256: 056c85b482d58faab5fd4670b6c1f5df0986314cca3bc831d458b22e4ef2c792
   build: h77eed37_1
-  arch: x86_64
-  subdir: linux-64
   build_number: 1
-  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
-  license_family: Other
-  noarch: generic
-  size: 1619820
-  timestamp: 1700944216729
-- platform: osx-arm64
-  name: font-ttf-ubuntu
-  version: '0.83'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
-  hash:
-    md5: 6185f640c43843e5ad6fd1c5372c3f80
-    sha256: 056c85b482d58faab5fd4670b6c1f5df0986314cca3bc831d458b22e4ef2c792
-  build: h77eed37_1
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+  sha256: 056c85b482d58faab5fd4670b6c1f5df0986314cca3bc831d458b22e4ef2c792
+  md5: 6185f640c43843e5ad6fd1c5372c3f80
+  arch: aarch64
+  platform: osx
   license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
   license_family: Other
-  noarch: generic
   size: 1619820
   timestamp: 1700944216729
-- platform: linux-64
+- kind: conda
   name: fontconfig
   version: 2.14.2
-  category: main
-  manager: conda
-  dependencies:
-  - expat >=2.5.0,<3.0a0
-  - freetype >=2.12.1,<3.0a0
-  - libgcc-ng >=12
-  - libuuid >=2.32.1,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
-  hash:
-    md5: 0f69b688f52ff6da70bccb7ff7001d1d
-    sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
-  build: h14ed4e7_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 272010
-  timestamp: 1674828850194
-- platform: osx-arm64
-  name: fontconfig
-  version: 2.14.2
-  category: main
-  manager: conda
-  dependencies:
-  - expat >=2.5.0,<3.0a0
-  - freetype >=2.12.1,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
-  hash:
-    md5: f77d47ddb6d3cc5b39b9bdf65635afbb
-    sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
   build: h82840c6_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+  sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
+  md5: f77d47ddb6d3cc5b39b9bdf65635afbb
+  depends:
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 237668
   timestamp: 1674829263740
-- platform: linux-64
+- kind: conda
   name: fonts-conda-ecosystem
   version: '1'
-  category: main
-  manager: conda
-  dependencies:
-  - fonts-conda-forge
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  hash:
-    md5: fee5683a3f04bd15cbd8318b096a27ab
-    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
   build: '0'
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: generic
-  size: 3667
-  timestamp: 1566974674465
-- platform: osx-arm64
-  name: fonts-conda-ecosystem
-  version: '1'
-  category: main
-  manager: conda
-  dependencies:
-  - fonts-conda-forge
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  hash:
-    md5: fee5683a3f04bd15cbd8318b096a27ab
-    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  build: '0'
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: generic
   size: 3667
   timestamp: 1566974674465
-- platform: linux-64
+- kind: conda
   name: fonts-conda-forge
   version: '1'
-  category: main
-  manager: conda
-  dependencies:
+  build: '0'
+  subdir: osx-arm64
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+  sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
+  md5: f766549260d6815b0c52253f1fb1bb29
+  depends:
   - font-ttf-dejavu-sans-mono
   - font-ttf-inconsolata
   - font-ttf-source-code-pro
   - font-ttf-ubuntu
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-  hash:
-    md5: f766549260d6815b0c52253f1fb1bb29
-    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  build: '0'
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: generic
   size: 4102
   timestamp: 1566932280397
-- platform: osx-arm64
-  name: fonts-conda-forge
-  version: '1'
-  category: main
-  manager: conda
-  dependencies:
-  - font-ttf-dejavu-sans-mono
-  - font-ttf-inconsolata
-  - font-ttf-source-code-pro
-  - font-ttf-ubuntu
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-  hash:
-    md5: f766549260d6815b0c52253f1fb1bb29
-    sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  build: '0'
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: generic
-  size: 4102
-  timestamp: 1566932280397
-- platform: linux-64
+- kind: pypi
   name: fonttools
-  version: 4.46.0
-  category: main
-  manager: conda
-  dependencies:
-  - brotli
-  - libgcc-ng >=12
-  - munkres
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - unicodedata2 >=14.0.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.46.0-py310h2372a71_0.conda
-  hash:
-    md5: 3c0109417cbcdabfed289360886b036d
-    sha256: 48682fe7bc12bae520dd67b3d6a84acdac52488d75278d91be62b266c8bb3c91
-  build: py310h2372a71_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 2302792
-  timestamp: 1701530936628
-- platform: osx-arm64
+  version: 4.51.0
+  url: https://files.pythonhosted.org/packages/3e/d8/db820b6243325f29e93de36273fdd48f3c1dce7fa859be5ed3708e174eba/fonttools-4.51.0-cp39-cp39-macosx_10_9_universal2.whl
+  sha256: 60a3409c9112aec02d5fb546f557bca6efa773dcb32ac147c6baf5f742e6258b
+  requires_dist:
+  - fs<3,>=2.2.0 ; extra == 'all'
+  - lxml>=4.0 ; extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
+  - pycairo ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - sympy ; extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.23.0 ; extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'all'
+  - xattr ; sys_platform == 'darwin' and extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
+  - pycairo ; extra == 'interpolatable'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+  - lxml>=4.0 ; extra == 'lxml'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
+  - matplotlib ; extra == 'plot'
+  - uharfbuzz>=0.23.0 ; extra == 'repacker'
+  - sympy ; extra == 'symfont'
+  - xattr ; sys_platform == 'darwin' and extra == 'type1'
+  - fs<3,>=2.2.0 ; extra == 'ufo'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'unicode'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  requires_python: '>=3.8'
+- kind: pypi
   name: fonttools
-  version: 4.46.0
-  category: main
-  manager: conda
-  dependencies:
-  - brotli
-  - munkres
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - unicodedata2 >=14.0.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.46.0-py310hd125d64_0.conda
-  hash:
-    md5: 7e9c223d92325ded794a35144a326341
-    sha256: 13dce32bf114d3a86b26f57f0306b160f21ba13dfbcc36f56f7ebe772398acaa
-  build: py310hd125d64_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 2192620
-  timestamp: 1701531142481
-- platform: linux-64
+  version: 4.51.0
+  url: https://files.pythonhosted.org/packages/8b/c6/636f008104908a93b80419f756be755bb91df4b8a0c88d5158bb52c82c3a/fonttools-4.51.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 0d145976194a5242fdd22df18a1b451481a88071feadf251221af110ca8f00ce
+  requires_dist:
+  - fs<3,>=2.2.0 ; extra == 'all'
+  - lxml>=4.0 ; extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
+  - pycairo ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - sympy ; extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.23.0 ; extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'all'
+  - xattr ; sys_platform == 'darwin' and extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
+  - pycairo ; extra == 'interpolatable'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+  - lxml>=4.0 ; extra == 'lxml'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
+  - matplotlib ; extra == 'plot'
+  - uharfbuzz>=0.23.0 ; extra == 'repacker'
+  - sympy ; extra == 'symfont'
+  - xattr ; sys_platform == 'darwin' and extra == 'type1'
+  - fs<3,>=2.2.0 ; extra == 'ufo'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'unicode'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  requires_python: '>=3.8'
+- kind: conda
   name: freetype
   version: 2.12.1
-  category: main
-  manager: conda
-  dependencies:
+  build: h267a509_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+  sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
+  md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
+  depends:
   - libgcc-ng >=12
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
-  hash:
-    md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
-    sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
-  build: h267a509_2
   arch: x86_64
-  subdir: linux-64
-  build_number: 2
+  platform: linux
   license: GPL-2.0-only OR FTL
   size: 634972
   timestamp: 1694615932610
-- platform: osx-arm64
+- kind: conda
   name: freetype
   version: 2.12.1
-  category: main
-  manager: conda
-  dependencies:
+  build: hadb7bae_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+  sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
+  md5: e6085e516a3e304ce41a8ee08b9b89ad
+  depends:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
-  hash:
-    md5: e6085e516a3e304ce41a8ee08b9b89ad
-    sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
-  build: hadb7bae_2
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
+  platform: osx
   license: GPL-2.0-only OR FTL
   size: 596430
   timestamp: 1694616332835
-- platform: linux-64
+- kind: pypi
   name: freetype-py
   version: 2.4.0
-  category: main
-  manager: conda
-  dependencies:
-  - freetype
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/freetype-py-2.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a9903594657eac3f87c1967ae1169bb3
-    sha256: b09ec82151787f0ee802c69518bdfad8330c5994a63a62cbbbf7ad81ab89bc15
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 62448
-  timestamp: 1683203002571
-- platform: osx-arm64
+  url: https://files.pythonhosted.org/packages/7c/77/faec42d1ffac2b970f606860a5bb083d606f1c673a5c57ab26382c8efec1/freetype_py-2.4.0-py3-none-macosx_10_9_universal2.whl
+  sha256: 3e0f5a91bc812f42d98a92137e86bac4ed037a29e43dafdb76d716d5732189e8
+  requires_python: '>=3.7'
+- kind: pypi
   name: freetype-py
   version: 2.4.0
-  category: main
-  manager: conda
-  dependencies:
-  - freetype
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/freetype-py-2.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a9903594657eac3f87c1967ae1169bb3
-    sha256: b09ec82151787f0ee802c69518bdfad8330c5994a63a62cbbbf7ad81ab89bc15
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 62448
-  timestamp: 1683203002571
-- platform: osx-arm64
+  url: https://files.pythonhosted.org/packages/5f/34/76cfe866e482745ea8c9956b0be6198fd72d08d2be77b71596afdb8cd89f/freetype_py-2.4.0-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+  sha256: ce931f581d5038c4fea1f3d314254e0264e92441a5fdaef6817fe77b7bb888d3
+  requires_python: '>=3.7'
+- kind: conda
   name: fribidi
   version: 1.0.10
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
-  hash:
-    md5: c64443234ff91d70cb9c7dc926c58834
-    sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
   build: h27ca646_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+  sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
+  md5: c64443234ff91d70cb9c7dc926c58834
+  arch: aarch64
+  platform: osx
   license: LGPL-2.1
   size: 60255
   timestamp: 1604417405528
-- platform: linux-64
+- kind: conda
   name: frozenlist
-  version: 1.4.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.0-py310h2372a71_1.conda
-  hash:
-    md5: c7b2865e86782925a872c8598b760c08
-    sha256: cd1e59ceac047d9f692bb7cc2a6a6e2356a7d3db660b076b4afb19d35db2fd02
-  build: py310h2372a71_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  version: 1.4.1
+  build: py39h17cfd9d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.4.1-py39h17cfd9d_0.conda
+  sha256: 6333178fa1e66eb8434e1ea4c6427083c0a6c7b762370e2e0b8c57f25dd7ea38
+  md5: 75f800eaf907952ec49d20f5393a5e27
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
   license: Apache-2.0
   license_family: APACHE
-  size: 53928
-  timestamp: 1695377871958
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/frozenlist
+  size: 53369
+  timestamp: 1702646028362
+- kind: conda
   name: frozenlist
-  version: 1.4.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.4.0-py310h2aa6e3c_1.conda
-  hash:
-    md5: 4f6aa33b93a158da819ca98bc129e735
-    sha256: c1db0602adcc7fec7b777f15f4fbc7dfb624d323ad37e4928364caa3c938035f
-  build: py310h2aa6e3c_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
+  version: 1.4.1
+  build: py39hd1e30aa_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py39hd1e30aa_0.conda
+  sha256: a011b537e04ef72d85ff47d7d60ebc815c457a2790a6ab8d77a0956db78b08e1
+  md5: 194fa03bd6b1054b8de8d48d335e45b2
+  depends:
+  - libgcc-ng >=12
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   license: Apache-2.0
   license_family: APACHE
-  size: 48827
-  timestamp: 1695378152026
-- platform: linux-64
+  purls:
+  - pkg:pypi/frozenlist
+  size: 60468
+  timestamp: 1702645649485
+- kind: conda
   name: fsspec
   version: 2023.12.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.12.1-pyhca7485f_0.conda
-  hash:
-    md5: b38946846cdf39f9bce93f75f571d913
-    sha256: 929e63a5916a8ebc50199d5404fdcedf75261580d8e229d9a1def57a05ef39eb
   build: pyhca7485f_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.12.1-pyhca7485f_0.conda
+  sha256: 929e63a5916a8ebc50199d5404fdcedf75261580d8e229d9a1def57a05ef39eb
+  md5: b38946846cdf39f9bce93f75f571d913
+  depends:
+  - python >=3.8
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/fsspec
   size: 127002
   timestamp: 1701793998528
-- platform: osx-arm64
-  name: fsspec
-  version: 2023.12.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/fsspec-2023.12.1-pyhca7485f_0.conda
-  hash:
-    md5: b38946846cdf39f9bce93f75f571d913
-    sha256: 929e63a5916a8ebc50199d5404fdcedf75261580d8e229d9a1def57a05ef39eb
-  build: pyhca7485f_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 127002
-  timestamp: 1701793998528
-- platform: linux-64
+- kind: conda
   name: future
   version: 0.18.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: fec8329fc739090f26a7d7803db254f1
-    sha256: b3d34bf4924cb80363c1ab57ac821393f118ffaa94f05368bf4044941163b65e
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 365520
-  timestamp: 1673596757510
-- platform: osx-arm64
-  name: future
-  version: 0.18.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: fec8329fc739090f26a7d7803db254f1
-    sha256: b3d34bf4924cb80363c1ab57ac821393f118ffaa94f05368bf4044941163b65e
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
+  sha256: b3d34bf4924cb80363c1ab57ac821393f118ffaa94f05368bf4044941163b65e
+  md5: fec8329fc739090f26a7d7803db254f1
+  depends:
+  - python >=3.8
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/future
   size: 365520
   timestamp: 1673596757510
-- platform: linux-64
+- kind: pypi
+  name: gdown
+  version: 5.2.0
+  url: https://files.pythonhosted.org/packages/54/70/e07c381e6488a77094f04c85c9caf1c8008cdc30778f7019bc52e5285ef0/gdown-5.2.0-py3-none-any.whl
+  sha256: 33083832d82b1101bdd0e9df3edd0fbc0e1c5f14c9d8c38d2a35bf1683b526d6
+  requires_dist:
+  - beautifulsoup4
+  - filelock
+  - requests[socks]
+  - tqdm
+  - build ; extra == 'test'
+  - mypy ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - ruff ; extra == 'test'
+  - twine ; extra == 'test'
+  - types-requests ; extra == 'test'
+  - types-setuptools ; extra == 'test'
+  requires_python: '>=3.8'
+- kind: conda
   name: gettext
   version: 0.21.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
-  hash:
-    md5: 14947d8770185e5153fdd04d4673ed37
-    sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
-  build: h27087fc_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 4320628
-  timestamp: 1665673494324
-- platform: osx-arm64
-  name: gettext
-  version: 0.21.1
-  category: main
-  manager: conda
-  dependencies:
-  - libiconv >=1.17,<2.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
-  hash:
-    md5: 63d2ff6fddfa74e5458488fd311bf635
-    sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
   build: h0186832_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+  sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
+  md5: 63d2ff6fddfa74e5458488fd311bf635
+  depends:
+  - libiconv >=1.17,<2.0a0
+  arch: aarch64
+  platform: osx
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
   size: 4021036
   timestamp: 1665674192347
-- platform: linux-64
-  name: gflags
-  version: 2.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  - libstdcxx-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
-  hash:
-    md5: cddaf2c63ea4a5901cf09524c490ecdc
-    sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
-  build: he1b5a44_1004
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1004
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 116549
-  timestamp: 1594303828933
-- platform: osx-arm64
-  name: gflags
-  version: 2.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=11.0.0.rc1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
-  hash:
-    md5: aab9ddfad863e9ef81229a1f8852211b
-    sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
-  build: hc88da5d_1004
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1004
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 86690
-  timestamp: 1599590990520
-- platform: linux-64
-  name: glib
-  version: 2.78.3
-  category: main
-  manager: conda
-  dependencies:
-  - gettext >=0.21.1,<1.0a0
-  - glib-tools 2.78.3 hfc55251_0
-  - libgcc-ng >=12
-  - libglib 2.78.3 h783c2da_0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - python *
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.3-hfc55251_0.conda
-  hash:
-    md5: e08e51acc7d1ae8dbe13255e7b4c64ac
-    sha256: 5c0630146185d806a4dd8cedd0e1983bc3a4ad8f9c0f1db8ee5fd28011396316
-  build: hfc55251_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.1-or-later
-  size: 489536
-  timestamp: 1702003193690
-- platform: linux-64
-  name: glib-tools
-  version: 2.78.3
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libglib 2.78.3 h783c2da_0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.3-hfc55251_0.conda
-  hash:
-    md5: 41d2f46e0ac8372eeb959860713d9b21
-    sha256: f7f9ed77beb5d0012a501abc7711f338ab9036f8d1e0259e71e3236bfcae2ad2
-  build: hfc55251_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.1-or-later
-  size: 110689
-  timestamp: 1702003133163
-- platform: linux-64
-  name: glog
-  version: 0.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - gflags >=2.2.2,<2.3.0a0
-  - libgcc-ng >=10.3.0
-  - libstdcxx-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
-  hash:
-    md5: b31f3565cb84435407594e548a2fb7b2
-    sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
-  build: h6f12383_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 114321
-  timestamp: 1649143789233
-- platform: osx-arm64
-  name: glog
-  version: 0.6.0
-  category: main
-  manager: conda
-  dependencies:
-  - gflags >=2.2.2,<2.3.0a0
-  - libcxx >=12.0.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
-  hash:
-    md5: 5a570729c7709399cf8511aeeda6f989
-    sha256: 4d772c42477f64be708594ac45870feba3e838977871118eb25e00deb0e9a73c
-  build: h6da1cb0_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 97658
-  timestamp: 1649144191039
-- platform: linux-64
+- kind: conda
   name: gmp
   version: 6.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_0.conda
+  sha256: 2a50495b6bbbacb03107ea0b752d8358d4a40b572d124a8cade068c147f344f5
+  md5: 0e33ef437202db431aa5a928248cf2e8
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_0.conda
-  hash:
-    md5: 0e33ef437202db431aa5a928248cf2e8
-    sha256: 2a50495b6bbbacb03107ea0b752d8358d4a40b572d124a8cade068c147f344f5
-  build: h59595ed_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: GPL-2.0-or-later AND LGPL-3.0-or-later
   size: 563123
   timestamp: 1699629991732
-- platform: osx-arm64
+- kind: conda
   name: gmp
   version: 6.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h965bd2d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h965bd2d_0.conda
+  sha256: d13f09ba46dc4732a3513da76da2352b9a6b71376dc3ba8210bbf1ca0c2e51e3
+  md5: bb8f17b25ebdb9d8819c2c5bf3ccb180
+  depends:
   - __osx >=10.9
   - libcxx >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h965bd2d_0.conda
-  hash:
-    md5: bb8f17b25ebdb9d8819c2c5bf3ccb180
-    sha256: d13f09ba46dc4732a3513da76da2352b9a6b71376dc3ba8210bbf1ca0c2e51e3
-  build: h965bd2d_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: GPL-2.0-or-later AND LGPL-3.0-or-later
   size: 446486
   timestamp: 1699630529917
-- platform: linux-64
+- kind: conda
   name: gnutls
   version: 3.6.13
-  category: main
-  manager: conda
-  dependencies:
+  build: h85f3911_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.6.13-h85f3911_1.tar.bz2
+  sha256: 6c9307f0fedce2c4d060bba9ac888b300bc0912effab423d67b8e1b661a93305
+  md5: 7d1b6fff16c1431d96cb4934938799fd
+  depends:
   - libgcc-ng >=7.5.0
   - libstdcxx-ng >=7.5.0
   - nettle >=3.4.1
   - nettle >=3.6,<3.7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.6.13-h85f3911_1.tar.bz2
-  hash:
-    md5: 7d1b6fff16c1431d96cb4934938799fd
-    sha256: 6c9307f0fedce2c4d060bba9ac888b300bc0912effab423d67b8e1b661a93305
-  build: h85f3911_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: LGPL-2.1-or-later
   license_family: LGPL
   size: 2096527
   timestamp: 1605742597225
-- platform: osx-arm64
+- kind: conda
   name: gnutls
   version: 3.7.9
-  category: main
-  manager: conda
-  dependencies:
+  build: hd26332c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
+  sha256: 800eceea27032e6d3edbb0186a76d62ed4e4c05963a7d43b35c2ced9ce27ba68
+  md5: 64af58bb3f2a635471dfbe798a1b81f5
+  depends:
   - __osx >=10.9
   - gettext >=0.21.1,<1.0a0
   - libcxx >=16.0.6
@@ -2856,24 +1869,22 @@ package:
   - libtasn1 >=4.19.0,<5.0a0
   - nettle >=3.9.1,<3.10.0a0
   - p11-kit >=0.24.1,<0.25.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
-  hash:
-    md5: 64af58bb3f2a635471dfbe798a1b81f5
-    sha256: 800eceea27032e6d3edbb0186a76d62ed4e4c05963a7d43b35c2ced9ce27ba68
-  build: hd26332c_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: LGPL-2.1-or-later
   license_family: LGPL
   size: 1829713
   timestamp: 1701110534084
-- platform: linux-64
+- kind: conda
   name: google-auth
   version: 2.25.2
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhca7485f_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.25.2-pyhca7485f_0.conda
+  sha256: 928960978bfdb77a912db60659ec30ec7e04d1ec12ba12f38ac61134158320d0
+  md5: ef008fe13beb99a47cbe5a7a68a1f0ea
+  depends:
   - aiohttp >=3.6.2,<4.0.0
   - cachetools >=2.0.0,<6.0
   - cryptography >=38.0.3
@@ -2883,282 +1894,103 @@ package:
   - pyu2f >=0.1.5
   - requests >=2.20.0,<3.0.0
   - rsa >=3.1.4,<5
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.25.2-pyhca7485f_0.conda
-  hash:
-    md5: ef008fe13beb99a47cbe5a7a68a1f0ea
-    sha256: 928960978bfdb77a912db60659ec30ec7e04d1ec12ba12f38ac61134158320d0
-  build: pyhca7485f_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 103345
-  timestamp: 1702091749559
-- platform: osx-arm64
-  name: google-auth
-  version: 2.25.2
-  category: main
-  manager: conda
-  dependencies:
-  - aiohttp >=3.6.2,<4.0.0
-  - cachetools >=2.0.0,<6.0
-  - cryptography >=38.0.3
-  - pyasn1-modules >=0.2.1
-  - pyopenssl >=20.0.0
-  - python >=3.7
-  - pyu2f >=0.1.5
-  - requests >=2.20.0,<3.0.0
-  - rsa >=3.1.4,<5
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-2.25.2-pyhca7485f_0.conda
-  hash:
-    md5: ef008fe13beb99a47cbe5a7a68a1f0ea
-    sha256: 928960978bfdb77a912db60659ec30ec7e04d1ec12ba12f38ac61134158320d0
-  build: pyhca7485f_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: Apache-2.0
   license_family: Apache
-  noarch: python
+  purls:
+  - pkg:pypi/google-auth
   size: 103345
   timestamp: 1702091749559
-- platform: linux-64
+- kind: conda
   name: google-auth-oauthlib
   version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.1.0-pyhd8ed1ab_0.conda
+  sha256: fc12c5a06b4d073c855cc2c43edff0b444af7b0db860f578fee1486769af0f21
+  md5: ffa1e2fd52bc00ec0fc5680a2f4bd167
+  depends:
   - click >=6.0.0
   - google-auth >=2.15.0
   - python >=3.6
   - requests-oauthlib >=0.7.0
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ffa1e2fd52bc00ec0fc5680a2f4bd167
-    sha256: fc12c5a06b4d073c855cc2c43edff0b444af7b0db860f578fee1486769af0f21
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 21437
-  timestamp: 1694470621292
-- platform: osx-arm64
-  name: google-auth-oauthlib
-  version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - click >=6.0.0
-  - google-auth >=2.15.0
-  - python >=3.6
-  - requests-oauthlib >=0.7.0
-  url: https://conda.anaconda.org/conda-forge/noarch/google-auth-oauthlib-1.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: ffa1e2fd52bc00ec0fc5680a2f4bd167
-    sha256: fc12c5a06b4d073c855cc2c43edff0b444af7b0db860f578fee1486769af0f21
-  build: pyhd8ed1ab_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: Apache-2.0
   license_family: Apache
-  noarch: python
+  purls:
+  - pkg:pypi/google-auth-oauthlib
   size: 21437
   timestamp: 1694470621292
-- platform: linux-64
+- kind: conda
   name: graphite2
   version: 1.3.13
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  - libstdcxx-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
-  hash:
-    md5: 8c54672728e8ec6aa6db90cf2806d220
-    sha256: 65da967f3101b737b08222de6a6a14e20e480e7d523a5d1e19ace7b960b5d6b1
-  build: h58526e2_1001
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1001
-  license: LGPLv2
-  size: 104701
-  timestamp: 1604365484436
-- platform: osx-arm64
-  name: graphite2
-  version: 1.3.13
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=11.0.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
-  hash:
-    md5: 288b591645cb9cb9c0af7309ac1114f5
-    sha256: 57db1e563cdfe469cd453a2988039118e96ce4b77c9219e2f1022be0e1c2b03f
   build: h9f76cd9_1001
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1001
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
+  sha256: 57db1e563cdfe469cd453a2988039118e96ce4b77c9219e2f1022be0e1c2b03f
+  md5: 288b591645cb9cb9c0af7309ac1114f5
+  depends:
+  - libcxx >=11.0.0
+  arch: aarch64
+  platform: osx
   license: LGPLv2
   size: 83198
   timestamp: 1604365687923
-- platform: linux-64
-  name: grpcio
-  version: 1.56.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libgrpc 1.56.2 h3905398_1
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.56.2-py310h1b8f574_1.conda
-  hash:
-    md5: 08d2538a6907851ea70d8f7cddc2f0d3
-    sha256: c2eda195f4de3210c1798439a37c075337d331ab2fe0cc9e4a6acb115a15a1ab
-  build: py310h1b8f574_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 764791
-  timestamp: 1692023633876
-- platform: osx-arm64
+- kind: conda
   name: grpcio
   version: 1.59.3
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libgrpc 1.59.3 hbcf6334_0
+  build: py39h174d805_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.59.3-py39h174d805_0.conda
+  sha256: 7136df5e62c5af83981e29733f95fe88140d9f02def426db5302f01777f43b24
+  md5: 936452359388a43140bec999adbba8e3
+  depends:
+  - libgcc-ng >=12
+  - libgrpc 1.59.3 hd6c4280_0
+  - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.59.3-py310h6121c79_0.conda
-  hash:
-    md5: a1383d819bad5bf1c8b43cc4141d8035
-    sha256: 904755429cdde59bbd571904299800fefc624df20adae05598bdf5a6e945a5cf
-  build: py310h6121c79_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   license: Apache-2.0
   license_family: APACHE
-  size: 918060
-  timestamp: 1700261545602
-- platform: linux-64
-  name: gst-plugins-base
-  version: 1.22.0
-  category: main
-  manager: conda
-  dependencies:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.8,<1.2.9.0a0
-  - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.22.0 h25f0c4b_2
-  - libgcc-ng >=12
-  - libglib >=2.74.1,<3.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libxcb >=1.13,<1.14.0a0
+  purls:
+  - pkg:pypi/grpcio
+  size: 999937
+  timestamp: 1700259775660
+- kind: conda
+  name: grpcio
+  version: 1.60.0
+  build: py39h047a24b_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.60.0-py39h047a24b_0.conda
+  sha256: 610154fc8bcfd4763991f262a57e16c48bfbba08ce6329931552572363af3998
+  md5: ba550a53ba9cdb21316366f901f825c9
+  depends:
+  - libcxx >=15
+  - libgrpc 1.60.0 hfc68871_0
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.0-h4243ec0_2.conda
-  hash:
-    md5: 0d0c6604c8ac4ad5e51efa7bb58da05c
-    sha256: e0f3e53f179440a8cdfd38c0b47d175aa560ff1600d43e15e6a6cbdaa7a01da3
-  build: h4243ec0_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 2708542
-  timestamp: 1678159510042
-- platform: linux-64
-  name: gstreamer
-  version: 1.22.0
-  category: main
-  manager: conda
-  dependencies:
-  - __glibc >=2.17,<3.0.a0
-  - gettext >=0.21.1,<1.0a0
-  - glib >=2.74.1,<3.0a0
-  - libgcc-ng >=12
-  - libglib >=2.74.1,<3.0a0
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.0-h25f0c4b_2.conda
-  hash:
-    md5: 461541cb1b387c2a28ab6217f3d38502
-    sha256: b60bf8f5cae60d276e26f9de0f03faddc6dd341c910924ffe0f3c1aa7e0852c7
-  build: h25f0c4b_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 1985068
-  timestamp: 1678159402537
-- platform: linux-64
-  name: gstreamer-orc
-  version: 0.4.34
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-orc-0.4.34-hd590300_0.conda
-  hash:
-    md5: 7ea223fa114cc8134b8c4d398d3e5afe
-    sha256: 4552b512b72a55d78cd7c76132965fa5c21472a44a0370cc6ca7042280f542c8
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-2-Clause AND BSD-3-Clause
-  size: 258562
-  timestamp: 1685465920207
-- platform: linux-64
-  name: harfbuzz
-  version: 6.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - cairo >=1.16.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2
-  - icu >=70.1,<71.0a0
-  - libgcc-ng >=12
-  - libglib >=2.74.1,<3.0a0
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-6.0.0-h8e241bc_0.conda
-  hash:
-    md5: 448fe40d2fed88ccf4d9ded37cbb2b38
-    sha256: f300fcb390253d6d63346ee71e56f82bc830783d1682ac933fe9ac86f39da942
-  build: h8e241bc_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 1300409
-  timestamp: 1671365973953
-- platform: osx-arm64
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/grpcio
+  size: 908115
+  timestamp: 1705977199632
+- kind: conda
   name: harfbuzz
   version: 8.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h8f0ba13_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.3.0-h8f0ba13_0.conda
+  sha256: 55e95aee9e5be7ada5a1cccedf1bb74c1362a7504cb0251fb48bcfa8bbd7cae3
+  md5: 71e7f9ba27feae122733bb9f1bfe594c
+  depends:
   - __osx >=10.9
   - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
@@ -3166,729 +1998,774 @@ package:
   - icu >=73.2,<74.0a0
   - libcxx >=16.0.6
   - libglib >=2.78.1,<3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.3.0-h8f0ba13_0.conda
-  hash:
-    md5: 71e7f9ba27feae122733bb9f1bfe594c
-    sha256: 55e95aee9e5be7ada5a1cccedf1bb74c1362a7504cb0251fb48bcfa8bbd7cae3
-  build: h8f0ba13_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
   size: 1295036
   timestamp: 1699925935335
-- platform: linux-64
-  name: huggingface_hub
-  version: 0.19.4
-  category: main
-  manager: conda
-  dependencies:
+- kind: pypi
+  name: huggingface-hub
+  version: 0.23.0
+  url: https://files.pythonhosted.org/packages/21/2b/516f82c5ba9beb184b24c11976be2ad5e80fb7fe6b2796c887087144445e/huggingface_hub-0.23.0-py3-none-any.whl
+  sha256: 075c30d48ee7db2bba779190dc526d2c11d422aed6f9044c5e2fdc2c432fdb91
+  requires_dist:
   - filelock
-  - fsspec >=2023.5.0
-  - packaging >=20.9
-  - python >=3.8
-  - pyyaml >=5.1
+  - fsspec>=2023.5.0
+  - packaging>=20.9
+  - pyyaml>=5.1
   - requests
-  - tqdm >=4.42.1
-  - typing-extensions >=3.7.4.3
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.19.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 89932559fd83abbc8f081f688a2e764f
-    sha256: 411e21dd3d54738f16208ec408b7cd88785dc7007ab4fe8db1aaf9f342fab279
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 205913
-  timestamp: 1700515516704
-- platform: osx-arm64
-  name: huggingface_hub
-  version: 0.19.4
-  category: main
-  manager: conda
-  dependencies:
-  - filelock
-  - fsspec >=2023.5.0
-  - packaging >=20.9
-  - python >=3.8
-  - pyyaml >=5.1
-  - requests
-  - tqdm >=4.42.1
-  - typing-extensions >=3.7.4.3
-  url: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.19.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 89932559fd83abbc8f081f688a2e764f
-    sha256: 411e21dd3d54738f16208ec408b7cd88785dc7007ab4fe8db1aaf9f342fab279
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 205913
-  timestamp: 1700515516704
-- platform: linux-64
+  - tqdm>=4.42.1
+  - typing-extensions>=3.7.4.3
+  - inquirerpy==0.3.4 ; extra == 'all'
+  - aiohttp ; extra == 'all'
+  - minijinja>=1.0 ; extra == 'all'
+  - jedi ; extra == 'all'
+  - jinja2 ; extra == 'all'
+  - pytest ; extra == 'all'
+  - pytest-cov ; extra == 'all'
+  - pytest-env ; extra == 'all'
+  - pytest-xdist ; extra == 'all'
+  - pytest-vcr ; extra == 'all'
+  - pytest-asyncio ; extra == 'all'
+  - pytest-rerunfailures ; extra == 'all'
+  - urllib3<2.0 ; extra == 'all'
+  - soundfile ; extra == 'all'
+  - pillow ; extra == 'all'
+  - gradio ; extra == 'all'
+  - numpy ; extra == 'all'
+  - fastapi ; extra == 'all'
+  - ruff>=0.3.0 ; extra == 'all'
+  - mypy==1.5.1 ; extra == 'all'
+  - typing-extensions>=4.8.0 ; extra == 'all'
+  - types-pyyaml ; extra == 'all'
+  - types-requests ; extra == 'all'
+  - types-simplejson ; extra == 'all'
+  - types-toml ; extra == 'all'
+  - types-tqdm ; extra == 'all'
+  - types-urllib3 ; extra == 'all'
+  - inquirerpy==0.3.4 ; extra == 'cli'
+  - inquirerpy==0.3.4 ; extra == 'dev'
+  - aiohttp ; extra == 'dev'
+  - minijinja>=1.0 ; extra == 'dev'
+  - jedi ; extra == 'dev'
+  - jinja2 ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - pytest-env ; extra == 'dev'
+  - pytest-xdist ; extra == 'dev'
+  - pytest-vcr ; extra == 'dev'
+  - pytest-asyncio ; extra == 'dev'
+  - pytest-rerunfailures ; extra == 'dev'
+  - urllib3<2.0 ; extra == 'dev'
+  - soundfile ; extra == 'dev'
+  - pillow ; extra == 'dev'
+  - gradio ; extra == 'dev'
+  - numpy ; extra == 'dev'
+  - fastapi ; extra == 'dev'
+  - ruff>=0.3.0 ; extra == 'dev'
+  - mypy==1.5.1 ; extra == 'dev'
+  - typing-extensions>=4.8.0 ; extra == 'dev'
+  - types-pyyaml ; extra == 'dev'
+  - types-requests ; extra == 'dev'
+  - types-simplejson ; extra == 'dev'
+  - types-toml ; extra == 'dev'
+  - types-tqdm ; extra == 'dev'
+  - types-urllib3 ; extra == 'dev'
+  - toml ; extra == 'fastai'
+  - fastai>=2.4 ; extra == 'fastai'
+  - fastcore>=1.3.27 ; extra == 'fastai'
+  - hf-transfer>=0.1.4 ; extra == 'hf_transfer'
+  - aiohttp ; extra == 'inference'
+  - minijinja>=1.0 ; extra == 'inference'
+  - ruff>=0.3.0 ; extra == 'quality'
+  - mypy==1.5.1 ; extra == 'quality'
+  - tensorflow ; extra == 'tensorflow'
+  - pydot ; extra == 'tensorflow'
+  - graphviz ; extra == 'tensorflow'
+  - tensorflow ; extra == 'tensorflow-testing'
+  - keras<3.0 ; extra == 'tensorflow-testing'
+  - inquirerpy==0.3.4 ; extra == 'testing'
+  - aiohttp ; extra == 'testing'
+  - minijinja>=1.0 ; extra == 'testing'
+  - jedi ; extra == 'testing'
+  - jinja2 ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-env ; extra == 'testing'
+  - pytest-xdist ; extra == 'testing'
+  - pytest-vcr ; extra == 'testing'
+  - pytest-asyncio ; extra == 'testing'
+  - pytest-rerunfailures ; extra == 'testing'
+  - urllib3<2.0 ; extra == 'testing'
+  - soundfile ; extra == 'testing'
+  - pillow ; extra == 'testing'
+  - gradio ; extra == 'testing'
+  - numpy ; extra == 'testing'
+  - fastapi ; extra == 'testing'
+  - torch ; extra == 'torch'
+  - safetensors ; extra == 'torch'
+  - typing-extensions>=4.8.0 ; extra == 'typing'
+  - types-pyyaml ; extra == 'typing'
+  - types-requests ; extra == 'typing'
+  - types-simplejson ; extra == 'typing'
+  - types-toml ; extra == 'typing'
+  - types-tqdm ; extra == 'typing'
+  - types-urllib3 ; extra == 'typing'
+  requires_python: '>=3.8.0'
+- kind: conda
   name: icu
   version: '70.1'
-  category: main
-  manager: conda
-  dependencies:
+  build: h27087fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-70.1-h27087fc_0.tar.bz2
+  sha256: 1d7950f3be4637ab915d886304e57731d39a41ab705ffc95c4681655c459374a
+  md5: 87473a15119779e021c314249d4b4aed
+  depends:
   - libgcc-ng >=10.3.0
   - libstdcxx-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-70.1-h27087fc_0.tar.bz2
-  hash:
-    md5: 87473a15119779e021c314249d4b4aed
-    sha256: 1d7950f3be4637ab915d886304e57731d39a41ab705ffc95c4681655c459374a
-  build: h27087fc_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: MIT
   license_family: MIT
   size: 14191488
   timestamp: 1648050221778
-- platform: osx-arm64
+- kind: conda
   name: icu
   version: '73.2'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
-  hash:
-    md5: 8521bd47c0e11c5902535bb1a17c565f
-    sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
   build: hc8870d7_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+  sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
+  md5: 8521bd47c0e11c5902535bb1a17c565f
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 11997841
   timestamp: 1692902104771
-- platform: linux-64
+- kind: conda
   name: idna
   version: '3.6'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1a76f09108576397c41c0b0c5bd84134
-    sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
+  sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
+  md5: 1a76f09108576397c41c0b0c5bd84134
+  depends:
+  - python >=3.6
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/idna
   size: 50124
   timestamp: 1701027126206
-- platform: osx-arm64
-  name: idna
-  version: '3.6'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1a76f09108576397c41c0b0c5bd84134
-    sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 50124
-  timestamp: 1701027126206
-- platform: linux-64
+- kind: pypi
   name: imageio
-  version: 2.31.5
-  category: main
-  manager: conda
-  dependencies:
+  version: 2.34.1
+  url: https://files.pythonhosted.org/packages/a3/b6/39c7dad203d9984225f47e0aa39ac3ba3a47c77a02d0ef2a7be691855a06/imageio-2.34.1-py3-none-any.whl
+  sha256: 408c1d4d62f72c9e8347e7d1ca9bc11d8673328af3913868db3b828e28b40a4c
+  requires_dist:
   - numpy
-  - pillow >=8.3.2
-  - python >=3
-  url: https://conda.anaconda.org/conda-forge/noarch/imageio-2.31.5-pyh8c1a49c_0.conda
-  hash:
-    md5: 6820ccf6a3a27df348f18c85dd89014a
-    sha256: 0554fbf2136a1ab380551963c5884941f7852034cbe40f002ae040e10e457365
-  build: pyh8c1a49c_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 291022
-  timestamp: 1696854244599
-- platform: osx-arm64
-  name: imageio
-  version: 2.31.5
-  category: main
-  manager: conda
-  dependencies:
-  - numpy
-  - pillow >=8.3.2
-  - python >=3
-  url: https://conda.anaconda.org/conda-forge/noarch/imageio-2.31.5-pyh8c1a49c_0.conda
-  hash:
-    md5: 6820ccf6a3a27df348f18c85dd89014a
-    sha256: 0554fbf2136a1ab380551963c5884941f7852034cbe40f002ae040e10e457365
-  build: pyh8c1a49c_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 291022
-  timestamp: 1696854244599
-- platform: linux-64
+  - pillow>=8.3.2
+  - astropy ; extra == 'all-plugins'
+  - av ; extra == 'all-plugins'
+  - imageio-ffmpeg ; extra == 'all-plugins'
+  - pillow-heif ; extra == 'all-plugins'
+  - psutil ; extra == 'all-plugins'
+  - tifffile ; extra == 'all-plugins'
+  - av ; extra == 'all-plugins-pypy'
+  - imageio-ffmpeg ; extra == 'all-plugins-pypy'
+  - pillow-heif ; extra == 'all-plugins-pypy'
+  - psutil ; extra == 'all-plugins-pypy'
+  - tifffile ; extra == 'all-plugins-pypy'
+  - wheel ; extra == 'build'
+  - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - fsspec[github] ; extra == 'dev'
+  - black ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - sphinx<6 ; extra == 'docs'
+  - numpydoc ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - imageio-ffmpeg ; extra == 'ffmpeg'
+  - psutil ; extra == 'ffmpeg'
+  - astropy ; extra == 'fits'
+  - astropy ; extra == 'full'
+  - av ; extra == 'full'
+  - black ; extra == 'full'
+  - flake8 ; extra == 'full'
+  - fsspec[github] ; extra == 'full'
+  - gdal ; extra == 'full'
+  - imageio-ffmpeg ; extra == 'full'
+  - itk ; extra == 'full'
+  - numpydoc ; extra == 'full'
+  - pillow-heif ; extra == 'full'
+  - psutil ; extra == 'full'
+  - pydata-sphinx-theme ; extra == 'full'
+  - pytest ; extra == 'full'
+  - pytest-cov ; extra == 'full'
+  - sphinx<6 ; extra == 'full'
+  - tifffile ; extra == 'full'
+  - wheel ; extra == 'full'
+  - gdal ; extra == 'gdal'
+  - itk ; extra == 'itk'
+  - black ; extra == 'linting'
+  - flake8 ; extra == 'linting'
+  - pillow-heif ; extra == 'pillow-heif'
+  - av ; extra == 'pyav'
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - fsspec[github] ; extra == 'test'
+  - tifffile ; extra == 'tifffile'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: imageio-ffmpeg
+  version: 0.4.9
+  url: https://files.pythonhosted.org/packages/28/c6/7f9990d8f9378bb4b8c60c08c2a1f565c44d9445c1f01fbbd5bed21379d9/imageio-ffmpeg-0.4.9.tar.gz
+  sha256: 39bcd1660118ef360fa4047456501071364661aa9d9021d3d26c58f1ee2081f5
+  requires_dist:
+  - setuptools
+  requires_python: '>=3.5'
+- kind: pypi
+  name: imageio-ffmpeg
+  version: 0.4.9
+  url: https://files.pythonhosted.org/packages/1a/98/3df1d8dd8f2c121b6c588b1e0d604f36592d56df9c41fb155ed546c6a5ed/imageio_ffmpeg-0.4.9-py3-none-manylinux2010_x86_64.whl
+  sha256: 2996c64af3e5489227096580269317719ea1a8121d207f2e28d6c24ebc4a253e
+  requires_dist:
+  - setuptools
+  requires_python: '>=3.5'
+- kind: conda
   name: importlib-metadata
   version: 7.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  - zipp >=0.5
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.0-pyha770c72_0.conda
-  hash:
-    md5: a941237cd06538837b25cd245fcd25d8
-    sha256: 9731e82a00d36b182dc515e31723e711ac82890bb1ca86c6a17a4b471135564f
   build: pyha770c72_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 26076
-  timestamp: 1701632335069
-- platform: osx-arm64
-  name: importlib-metadata
-  version: 7.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  - zipp >=0.5
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.0-pyha770c72_0.conda
-  hash:
-    md5: a941237cd06538837b25cd245fcd25d8
-    sha256: 9731e82a00d36b182dc515e31723e711ac82890bb1ca86c6a17a4b471135564f
-  build: pyha770c72_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.0-pyha770c72_0.conda
+  sha256: 9731e82a00d36b182dc515e31723e711ac82890bb1ca86c6a17a4b471135564f
+  md5: a941237cd06538837b25cd245fcd25d8
+  depends:
+  - python >=3.8
+  - zipp >=0.5
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
+  purls:
+  - pkg:pypi/importlib-metadata
   size: 26076
   timestamp: 1701632335069
-- platform: linux-64
-  name: jack
-  version: 1.9.22
-  category: main
-  manager: conda
-  dependencies:
-  - alsa-lib >=1.2.8,<1.2.9.0a0
-  - libdb >=6.2.32,<6.3.0a0
-  - libgcc-ng >=12
-  - libopus >=1.3.1,<2.0a0
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/jack-1.9.22-h11f4161_0.conda
-  hash:
-    md5: 504fa9e712b99494a9cf4630e3ca7d78
-    sha256: 9f173c6633f7ef049b05cd92a9fc028402972ddc44a56d5bb51d8879d73bbde7
-  build: h11f4161_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.0-only
-  license_family: LGPL
-  size: 463582
-  timestamp: 1675358702299
-- platform: linux-64
+- kind: pypi
+  name: importlib-resources
+  version: 6.4.0
+  url: https://files.pythonhosted.org/packages/75/06/4df55e1b7b112d183f65db9503bff189e97179b256e1ea450a3c365241e0/importlib_resources-6.4.0-py3-none-any.whl
+  sha256: 50d10f043df931902d4194ea07ec57960f66a80449ff867bfe782b4c486ba78c
+  requires_dist:
+  - zipp>=3.1.0 ; python_version < '3.10'
+  - sphinx>=3.5 ; extra == 'docs'
+  - sphinx<7.2.5 ; extra == 'docs'
+  - jaraco-packaging>=9.3 ; extra == 'docs'
+  - rst-linker>=1.9 ; extra == 'docs'
+  - furo ; extra == 'docs'
+  - sphinx-lint ; extra == 'docs'
+  - jaraco-tidelift>=1.4 ; extra == 'docs'
+  - pytest>=6 ; extra == 'testing'
+  - pytest-checkdocs>=2.4 ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-enabler>=2.2 ; extra == 'testing'
+  - pytest-ruff>=0.2.1 ; extra == 'testing'
+  - zipp>=3.17 ; extra == 'testing'
+  - jaraco-test>=5.4 ; extra == 'testing'
+  - pytest-mypy ; platform_python_implementation != 'PyPy' and extra == 'testing'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: ipython
+  version: 8.18.1
+  url: https://files.pythonhosted.org/packages/47/6b/d9fdcdef2eb6a23f391251fde8781c38d42acd82abe84d054cb74f7863b0/ipython-8.18.1-py3-none-any.whl
+  sha256: e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397
+  requires_dist:
+  - decorator
+  - jedi>=0.16
+  - matplotlib-inline
+  - prompt-toolkit<3.1.0,>=3.0.41
+  - pygments>=2.4.0
+  - stack-data
+  - traitlets>=5
+  - typing-extensions ; python_version < '3.10'
+  - exceptiongroup ; python_version < '3.11'
+  - pexpect>4.3 ; sys_platform != 'win32'
+  - colorama ; sys_platform == 'win32'
+  - black ; extra == 'all'
+  - ipykernel ; extra == 'all'
+  - setuptools>=18.5 ; extra == 'all'
+  - sphinx>=1.3 ; extra == 'all'
+  - sphinx-rtd-theme ; extra == 'all'
+  - docrepr ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - stack-data ; extra == 'all'
+  - pytest<7 ; extra == 'all'
+  - typing-extensions ; extra == 'all'
+  - exceptiongroup ; extra == 'all'
+  - pytest<7.1 ; extra == 'all'
+  - pytest-asyncio<0.22 ; extra == 'all'
+  - testpath ; extra == 'all'
+  - pickleshare ; extra == 'all'
+  - nbconvert ; extra == 'all'
+  - nbformat ; extra == 'all'
+  - ipywidgets ; extra == 'all'
+  - notebook ; extra == 'all'
+  - ipyparallel ; extra == 'all'
+  - qtconsole ; extra == 'all'
+  - curio ; extra == 'all'
+  - matplotlib!=3.2.0 ; extra == 'all'
+  - numpy>=1.22 ; extra == 'all'
+  - pandas ; extra == 'all'
+  - trio ; extra == 'all'
+  - black ; extra == 'black'
+  - ipykernel ; extra == 'doc'
+  - setuptools>=18.5 ; extra == 'doc'
+  - sphinx>=1.3 ; extra == 'doc'
+  - sphinx-rtd-theme ; extra == 'doc'
+  - docrepr ; extra == 'doc'
+  - matplotlib ; extra == 'doc'
+  - stack-data ; extra == 'doc'
+  - pytest<7 ; extra == 'doc'
+  - typing-extensions ; extra == 'doc'
+  - exceptiongroup ; extra == 'doc'
+  - pytest<7.1 ; extra == 'doc'
+  - pytest-asyncio<0.22 ; extra == 'doc'
+  - testpath ; extra == 'doc'
+  - pickleshare ; extra == 'doc'
+  - ipykernel ; extra == 'kernel'
+  - nbconvert ; extra == 'nbconvert'
+  - nbformat ; extra == 'nbformat'
+  - ipywidgets ; extra == 'notebook'
+  - notebook ; extra == 'notebook'
+  - ipyparallel ; extra == 'parallel'
+  - qtconsole ; extra == 'qtconsole'
+  - pytest<7.1 ; extra == 'test'
+  - pytest-asyncio<0.22 ; extra == 'test'
+  - testpath ; extra == 'test'
+  - pickleshare ; extra == 'test'
+  - pytest<7.1 ; extra == 'test_extra'
+  - pytest-asyncio<0.22 ; extra == 'test_extra'
+  - testpath ; extra == 'test_extra'
+  - pickleshare ; extra == 'test_extra'
+  - curio ; extra == 'test_extra'
+  - matplotlib!=3.2.0 ; extra == 'test_extra'
+  - nbformat ; extra == 'test_extra'
+  - numpy>=1.22 ; extra == 'test_extra'
+  - pandas ; extra == 'test_extra'
+  - trio ; extra == 'test_extra'
+  requires_python: '>=3.9'
+- kind: pypi
+  name: ipywidgets
+  version: 8.1.2
+  url: https://files.pythonhosted.org/packages/70/1a/7edeedb1c089d63ccd8bd5c0612334774e90cf9337de9fe6c82d90081791/ipywidgets-8.1.2-py3-none-any.whl
+  sha256: bbe43850d79fb5e906b14801d6c01402857996864d1e5b6fa62dd2ee35559f60
+  requires_dist:
+  - comm>=0.1.3
+  - ipython>=6.1.0
+  - traitlets>=4.3.1
+  - widgetsnbextension~=4.0.10
+  - jupyterlab-widgets~=3.0.10
+  - jsonschema ; extra == 'test'
+  - ipykernel ; extra == 'test'
+  - pytest>=3.6.0 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytz ; extra == 'test'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: itsdangerous
+  version: 2.2.0
+  url: https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl
+  sha256: c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef
+  requires_python: '>=3.8'
+- kind: pypi
+  name: jedi
+  version: 0.19.1
+  url: https://files.pythonhosted.org/packages/20/9f/bc63f0f0737ad7a60800bfd472a4836661adae21f9c2535f3957b1e54ceb/jedi-0.19.1-py2.py3-none-any.whl
+  sha256: e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0
+  requires_dist:
+  - parso<0.9.0,>=0.8.3
+  - jinja2==2.11.3 ; extra == 'docs'
+  - markupsafe==1.1.1 ; extra == 'docs'
+  - pygments==2.8.1 ; extra == 'docs'
+  - alabaster==0.7.12 ; extra == 'docs'
+  - babel==2.9.1 ; extra == 'docs'
+  - chardet==4.0.0 ; extra == 'docs'
+  - commonmark==0.8.1 ; extra == 'docs'
+  - docutils==0.17.1 ; extra == 'docs'
+  - future==0.18.2 ; extra == 'docs'
+  - idna==2.10 ; extra == 'docs'
+  - imagesize==1.2.0 ; extra == 'docs'
+  - mock==1.0.1 ; extra == 'docs'
+  - packaging==20.9 ; extra == 'docs'
+  - pyparsing==2.4.7 ; extra == 'docs'
+  - pytz==2021.1 ; extra == 'docs'
+  - readthedocs-sphinx-ext==2.1.4 ; extra == 'docs'
+  - recommonmark==0.5.0 ; extra == 'docs'
+  - requests==2.25.1 ; extra == 'docs'
+  - six==1.15.0 ; extra == 'docs'
+  - snowballstemmer==2.1.0 ; extra == 'docs'
+  - sphinx-rtd-theme==0.4.3 ; extra == 'docs'
+  - sphinx==1.8.5 ; extra == 'docs'
+  - sphinxcontrib-serializinghtml==1.1.4 ; extra == 'docs'
+  - sphinxcontrib-websupport==1.2.4 ; extra == 'docs'
+  - urllib3==1.26.4 ; extra == 'docs'
+  - flake8==5.0.4 ; extra == 'qa'
+  - mypy==0.971 ; extra == 'qa'
+  - types-setuptools==67.2.0.1 ; extra == 'qa'
+  - django ; extra == 'testing'
+  - attrs ; extra == 'testing'
+  - colorama ; extra == 'testing'
+  - docopt ; extra == 'testing'
+  - pytest<7.0.0 ; extra == 'testing'
+  requires_python: '>=3.6'
+- kind: pypi
+  name: jinja2
+  version: 3.1.4
+  url: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
+  sha256: bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
+  requires_dist:
+  - markupsafe>=2.0
+  - babel>=2.7 ; extra == 'i18n'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: joblib
+  version: 1.4.2
+  url: https://files.pythonhosted.org/packages/91/29/df4b9b42f2be0b623cbd5e2140cafcaa2bef0759a00b7b70104dcfe2fb51/joblib-1.4.2-py3-none-any.whl
+  sha256: 06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6
+  requires_python: '>=3.8'
+- kind: conda
   name: jpeg
   version: 9e
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
-  hash:
-    md5: c7a069243e1fbe9a556ed2ec030e6407
-    sha256: 8f73194d09c9ea4a7e2b3562766b8d72125cc147b62c7cf83393e3a3bbfd581b
   build: h0b41bf4_3
-  arch: x86_64
-  subdir: linux-64
   build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/jpeg-9e-h0b41bf4_3.conda
+  sha256: 8f73194d09c9ea4a7e2b3562766b8d72125cc147b62c7cf83393e3a3bbfd581b
+  md5: c7a069243e1fbe9a556ed2ec030e6407
+  depends:
+  - libgcc-ng >=12
   constrains:
   - libjpeg-turbo <0.0.0a
+  arch: x86_64
+  platform: linux
   license: IJG
   size: 240359
   timestamp: 1676177310738
-- platform: osx-arm64
+- kind: conda
   name: jpeg
   version: 9e
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jpeg-9e-h1a8c8d9_3.conda
-  hash:
-    md5: ef1cce2ab799e0c2f32c3344125ff218
-    sha256: 7e21d03917fb535b39c3af0cc7b7115617556a4ca2fe13018c09407987883b34
   build: h1a8c8d9_3
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jpeg-9e-h1a8c8d9_3.conda
+  sha256: 7e21d03917fb535b39c3af0cc7b7115617556a4ca2fe13018c09407987883b34
+  md5: ef1cce2ab799e0c2f32c3344125ff218
   constrains:
   - libjpeg-turbo <0.0.0a
+  arch: aarch64
+  platform: osx
   license: IJG
   size: 218587
   timestamp: 1676177519876
-- platform: linux-64
-  name: keyutils
-  version: 1.6.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=10.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
-  hash:
-    md5: 30186d27e2c9fa62b45fb1476b7200e3
-    sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
-  build: h166bdaf_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.1-or-later
-  size: 117831
-  timestamp: 1646151697040
-- platform: linux-64
+- kind: pypi
+  name: jsonschema
+  version: 4.22.0
+  url: https://files.pythonhosted.org/packages/c8/2f/324fab4be6fe37fb7b521546e8a557e6cf08c1c1b3d0b4839a00f589d9ef/jsonschema-4.22.0-py3-none-any.whl
+  sha256: ff4cfd6b1367a40e7bc6411caec72effadd3db0bbe5017de188f2d6108335802
+  requires_dist:
+  - attrs>=22.2.0
+  - importlib-resources>=1.4.0 ; python_version < '3.9'
+  - jsonschema-specifications>=2023.3.6
+  - pkgutil-resolve-name>=1.3.10 ; python_version < '3.9'
+  - referencing>=0.28.4
+  - rpds-py>=0.7.1
+  - fqdn ; extra == 'format'
+  - idna ; extra == 'format'
+  - isoduration ; extra == 'format'
+  - jsonpointer>1.13 ; extra == 'format'
+  - rfc3339-validator ; extra == 'format'
+  - rfc3987 ; extra == 'format'
+  - uri-template ; extra == 'format'
+  - webcolors>=1.11 ; extra == 'format'
+  - fqdn ; extra == 'format-nongpl'
+  - idna ; extra == 'format-nongpl'
+  - isoduration ; extra == 'format-nongpl'
+  - jsonpointer>1.13 ; extra == 'format-nongpl'
+  - rfc3339-validator ; extra == 'format-nongpl'
+  - rfc3986-validator>0.1.0 ; extra == 'format-nongpl'
+  - uri-template ; extra == 'format-nongpl'
+  - webcolors>=1.11 ; extra == 'format-nongpl'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: jsonschema-specifications
+  version: 2023.12.1
+  url: https://files.pythonhosted.org/packages/ee/07/44bd408781594c4d0a027666ef27fab1e441b109dc3b76b4f836f8fd04fe/jsonschema_specifications-2023.12.1-py3-none-any.whl
+  sha256: 87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c
+  requires_dist:
+  - importlib-resources>=1.4.0 ; python_version < '3.9'
+  - referencing>=0.31.0
+  requires_python: '>=3.8'
+- kind: pypi
+  name: jupyter-core
+  version: 5.7.2
+  url: https://files.pythonhosted.org/packages/c9/fb/108ecd1fe961941959ad0ee4e12ee7b8b1477247f30b1fdfd83ceaf017f0/jupyter_core-5.7.2-py3-none-any.whl
+  sha256: 4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409
+  requires_dist:
+  - platformdirs>=2.5
+  - pywin32>=300 ; sys_platform == 'win32' and platform_python_implementation != 'PyPy'
+  - traitlets>=5.3
+  - myst-parser ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - sphinx-autodoc-typehints ; extra == 'docs'
+  - sphinxcontrib-github-alt ; extra == 'docs'
+  - sphinxcontrib-spelling ; extra == 'docs'
+  - traitlets ; extra == 'docs'
+  - ipykernel ; extra == 'test'
+  - pre-commit ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest<8 ; extra == 'test'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: jupyterlab-widgets
+  version: 3.0.10
+  url: https://files.pythonhosted.org/packages/24/da/db1cb0387a7e4086780aff137987ee924e953d7f91b2a870f994b9b1eeb8/jupyterlab_widgets-3.0.10-py3-none-any.whl
+  sha256: dd61f3ae7a5a7f80299e14585ce6cf3d6925a96c9103c978eda293197730cb64
+  requires_python: '>=3.7'
+- kind: pypi
   name: kiwisolver
   version: 1.4.5
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py310hd41b1e2_1.conda
-  hash:
-    md5: b8d67603d43b23ce7e988a5d81a7ab79
-    sha256: bb51906639bced3de1d4d7740ac284cdaa89e2f22e0b1ec796378b090b0648ba
-  build: py310hd41b1e2_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 73123
-  timestamp: 1695380074542
-- platform: osx-arm64
+  url: https://files.pythonhosted.org/packages/89/a8/3b7e14121bea4438b87630557645bb7648b17b54acaa39b93f4bf7f8d33e/kiwisolver-1.4.5-cp39-cp39-macosx_11_0_arm64.whl
+  sha256: 0dc9db8e79f0036e8173c466d21ef18e1befc02de8bf8aa8dc0813a6dc8a7046
+  requires_dist:
+  - typing-extensions ; python_version < '3.8'
+  requires_python: '>=3.7'
+- kind: pypi
   name: kiwisolver
   version: 1.4.5
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py310h38f39d4_1.conda
-  hash:
-    md5: 84392f391faad11ea910f38226590a88
-    sha256: e84793b3bef7e5d92f96c511a06dc9cbcc49424995777595365c654effe67d6f
-  build: py310h38f39d4_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 62043
-  timestamp: 1695380329047
-- platform: linux-64
+  url: https://files.pythonhosted.org/packages/c0/a8/841594f11d0b88d8aeb26991bc4dac38baa909dc58d0c4262a4f7893bcbf/kiwisolver-1.4.5-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+  sha256: 6c3bd3cde54cafb87d74d8db50b909705c62b17c2099b8f2e25b461882e544ff
+  requires_dist:
+  - typing-extensions ; python_version < '3.8'
+  requires_python: '>=3.7'
+- kind: pypi
   name: kornia
   version: 0.6.7
-  category: main
-  manager: conda
-  dependencies:
+  url: https://files.pythonhosted.org/packages/7a/7f/5ec91cec58e02a41b1b0ea0fe9f0b2506cb68d497cf94382d464b2af77f4/kornia-0.6.7-py2.py3-none-any.whl
+  sha256: e2908d888a3043bd6f950c514f00c1589f8d43cc25e4fb9b3ad1e66375146826
+  requires_dist:
+  - torch>=1.8.1
   - packaging
-  - python >=3.7
-  - pytorch >=1.10
-  url: https://conda.anaconda.org/conda-forge/noarch/kornia-0.6.7-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: a1921a408ce0423e73fd629a1f4b9d54
-    sha256: 4d209dc68a06c2d0d9faf543f22e53f1e8c5b314f9e6c978b2de653bc50f0081
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 343392
-  timestamp: 1661903221327
-- platform: osx-arm64
-  name: kornia
-  version: 0.6.7
-  category: main
-  manager: conda
-  dependencies:
-  - packaging
-  - python >=3.7
-  - pytorch >=1.10
-  url: https://conda.anaconda.org/conda-forge/noarch/kornia-0.6.7-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: a1921a408ce0423e73fd629a1f4b9d54
-    sha256: 4d209dc68a06c2d0d9faf543f22e53f1e8c5b314f9e6c978b2de653bc50f0081
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 343392
-  timestamp: 1661903221327
-- platform: linux-64
-  name: krb5
-  version: 1.20.1
-  category: main
-  manager: conda
-  dependencies:
-  - keyutils >=1.6.1,<2.0a0
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.0.7,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.20.1-h81ceb04_0.conda
-  hash:
-    md5: 89a41adce7106749573d883b2f657d78
-    sha256: 51a346807ce981e1450eb04c3566415b05eed705bc9e6c98c198ec62367b7c62
-  build: h81ceb04_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 1329877
-  timestamp: 1671091750695
-- platform: osx-arm64
-  name: krb5
-  version: 1.21.2
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.1.2,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
-  hash:
-    md5: 92f1cff174a538e0722bf2efb16fc0b2
-    sha256: 70bdb9b4589ec7c7d440e485ae22b5a352335ffeb91a771d4c162996c3070875
-  build: h92f50d5_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 1195575
-  timestamp: 1692098070699
-- platform: linux-64
+  - accelerate==0.12.0 ; extra == 'all'
+  - pytest==7.1.2 ; extra == 'all'
+  - flake8==5.0.4 ; extra == 'all'
+  - pytest-cov==3.0.0 ; extra == 'all'
+  - pytest-mypy==0.9.1 ; extra == 'all'
+  - pydocstyle ; extra == 'all'
+  - pre-commit>=2.0 ; extra == 'all'
+  - isort ; extra == 'all'
+  - numpy ; extra == 'all'
+  - scipy ; extra == 'all'
+  - opencv-python ; extra == 'all'
+  - dataclasses ; python_version < '3.7' and extra == 'all'
+  - kornia-rs==0.0.5 ; python_version >= '3.7' and extra == 'all'
+  - pytest==7.1.2 ; extra == 'dev'
+  - flake8==5.0.4 ; extra == 'dev'
+  - pytest-cov==3.0.0 ; extra == 'dev'
+  - pytest-mypy==0.9.1 ; extra == 'dev'
+  - pydocstyle ; extra == 'dev'
+  - pre-commit>=2.0 ; extra == 'dev'
+  - isort ; extra == 'dev'
+  - numpy ; extra == 'dev'
+  - scipy ; extra == 'dev'
+  - opencv-python ; extra == 'dev'
+  - kornia-rs==0.0.5 ; python_version >= '3.7' and extra == 'dev'
+  - accelerate==0.12.0 ; extra == 'x'
+  - dataclasses ; python_version < '3.7' and extra == 'x'
+  requires_python: '>=3.6'
+- kind: conda
   name: lame
   version: '3.100'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
-  hash:
-    md5: a8832b479f93521a9e7b5b743803be51
-    sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
   build: h166bdaf_1003
-  arch: x86_64
-  subdir: linux-64
   build_number: 1003
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+  sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
+  md5: a8832b479f93521a9e7b5b743803be51
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.0-only
   license_family: LGPL
   size: 508258
   timestamp: 1664996250081
-- platform: osx-arm64
+- kind: conda
   name: lame
   version: '3.100'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
-  hash:
-    md5: bff0e851d66725f78dc2fd8b032ddb7e
-    sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
   build: h1a8c8d9_1003
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1003
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
+  sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
+  md5: bff0e851d66725f78dc2fd8b032ddb7e
+  arch: aarch64
+  platform: osx
   license: LGPL-2.0-only
   license_family: LGPL
   size: 528805
   timestamp: 1664996399305
-- platform: linux-64
+- kind: pypi
+  name: lazy-loader
+  version: '0.4'
+  url: https://files.pythonhosted.org/packages/83/60/d497a310bde3f01cb805196ac61b7ad6dc5dcf8dce66634dc34364b20b4f/lazy_loader-0.4-py3-none-any.whl
+  sha256: 342aa8e14d543a154047afb4ba8ef17f5563baad3fc610d7b15b213b0f119efc
+  requires_dist:
+  - packaging
+  - importlib-metadata ; python_version < '3.8'
+  - changelist==0.5 ; extra == 'dev'
+  - pre-commit==3.7.0 ; extra == 'lint'
+  - pytest>=7.4 ; extra == 'test'
+  - pytest-cov>=4.1 ; extra == 'test'
+  requires_python: '>=3.7'
+- kind: conda
   name: lcms2
   version: '2.15'
-  category: main
-  manager: conda
-  dependencies:
-  - jpeg >=9e,<10a
-  - libgcc-ng >=12
-  - libtiff >=4.5.0,<4.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hfd0df8a_0.conda
-  hash:
-    md5: aa8840cdf17ef0c6084d1e24abc7a28b
-    sha256: 443e926b585528112ec6aa4d85bf087722914ed8d85a2f75ae47c023c55c4238
-  build: hfd0df8a_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 240794
-  timestamp: 1678211140434
-- platform: osx-arm64
-  name: lcms2
-  version: '2.15'
-  category: main
-  manager: conda
-  dependencies:
-  - jpeg >=9e,<10a
-  - libtiff >=4.5.0,<4.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-h481adae_0.conda
-  hash:
-    md5: 806395a21421da524d72aa4e0b69d54c
-    sha256: 225028d2cea4e2974415245e4521c85f4baca08bc1103de44b5f8d6994bf2b9f
   build: h481adae_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-h481adae_0.conda
+  sha256: 225028d2cea4e2974415245e4521c85f4baca08bc1103de44b5f8d6994bf2b9f
+  md5: 806395a21421da524d72aa4e0b69d54c
+  depends:
+  - jpeg >=9e,<10a
+  - libtiff >=4.5.0,<4.6.0a0
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 205835
   timestamp: 1678104773395
-- platform: linux-64
+- kind: conda
+  name: lcms2
+  version: '2.15'
+  build: hfd0df8a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hfd0df8a_0.conda
+  sha256: 443e926b585528112ec6aa4d85bf087722914ed8d85a2f75ae47c023c55c4238
+  md5: aa8840cdf17ef0c6084d1e24abc7a28b
+  depends:
+  - jpeg >=9e,<10a
+  - libgcc-ng >=12
+  - libtiff >=4.5.0,<4.6.0a0
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 240794
+  timestamp: 1678211140434
+- kind: conda
   name: ld_impl_linux-64
   version: '2.40'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
-  hash:
-    md5: 7aca3059a1729aa76c597603f10b0dd3
-    sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
   build: h41732ed_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+  md5: 7aca3059a1729aa76c597603f10b0dd3
   constrains:
   - binutils_impl_linux-64 2.40
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   size: 704696
   timestamp: 1674833944779
-- platform: linux-64
+- kind: conda
   name: lerc
   version: 4.0.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h27087fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+  sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
+  md5: 76bbff344f0134279f225174e9064c8f
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
-  hash:
-    md5: 76bbff344f0134279f225174e9064c8f
-    sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
-  build: h27087fc_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 281798
   timestamp: 1657977462600
-- platform: osx-arm64
+- kind: conda
   name: lerc
   version: 4.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=13.0.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
-  hash:
-    md5: de462d5aacda3b30721b512c5da4e742
-    sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
   build: h9a09cb3_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+  sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+  md5: de462d5aacda3b30721b512c5da4e742
+  depends:
+  - libcxx >=13.0.1
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 215721
   timestamp: 1657977558796
-- platform: linux-64
-  name: libabseil
-  version: '20230125.3'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230125.3-cxx17_h59595ed_0.conda
-  hash:
-    md5: d1db1b8be7c3a8983dcbbbfe4f0765de
-    sha256: 3c6fab31ed4dc8428605588454596b307b1bd59d33b0c7073c407ab51408b011
-  build: cxx17_h59595ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - abseil-cpp =20230125.3
-  - libabseil-static =20230125.3=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1240376
-  timestamp: 1688112986128
-- platform: osx-arm64
+- kind: conda
   name: libabseil
   version: '20230802.1'
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
-  hash:
-    md5: fb6dfadc1898666616dfda242d8aea10
-    sha256: 459a58f36607246b4483d7a370c2d9a03e7f824e79da2c6e3e9d62abf80393e7
   build: cxx17_h13dd4ca_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
+  sha256: 459a58f36607246b4483d7a370c2d9a03e7f824e79da2c6e3e9d62abf80393e7
+  md5: fb6dfadc1898666616dfda242d8aea10
+  depends:
+  - libcxx >=15.0.7
   constrains:
   - libabseil-static =20230802.1=cxx17*
   - abseil-cpp =20230802.1
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 1173407
   timestamp: 1695064439482
-- platform: linux-64
-  name: libarrow
-  version: 10.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - aws-crt-cpp >=0.20.3,<0.20.4.0a0
-  - aws-sdk-cpp >=1.10.57,<1.10.58.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - gflags >=2.2.2,<2.3.0a0
-  - glog >=0.6.0,<0.7.0a0
-  - libabseil * cxx17*
-  - libabseil >=20230125.3,<20230126.0a0
-  - libbrotlidec >=1.0.9,<1.1.0a0
-  - libbrotlienc >=1.0.9,<1.1.0a0
-  - libgcc-ng >=12
-  - libgoogle-cloud >=2.12.0,<2.13.0a0
-  - libgrpc >=1.56.2,<1.57.0a0
-  - libprotobuf >=4.23.3,<4.23.4.0a0
-  - libstdcxx-ng >=12
-  - libthrift >=0.18.1,<0.18.2.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.1.1,<4.0a0
-  - orc >=1.9.0,<1.9.1.0a0
-  - re2 >=2023.3.2,<2023.3.3.0a0
-  - snappy >=1.1.10,<2.0a0
-  - ucx >=1.14.0,<1.15.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-10.0.1-h657c46f_36_cpu.conda
-  hash:
-    md5: 29eace609024d785608df7d63b75cb35
-    sha256: cdab5775178d6e46ff6e234da07a9a953b8a6085cf25c64eb7070f55df050e5e
-  build: h657c46f_36_cpu
-  arch: x86_64
+- kind: conda
+  name: libabseil
+  version: '20230802.1'
+  build: cxx17_h59595ed_0
   subdir: linux-64
-  build_number: 36
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
+  sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
+  md5: 2785ddf4cb0e7e743477991d64353947
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   constrains:
-  - apache-arrow-proc =*=cpu
-  - parquet-cpp <0.0a0
-  - arrow-cpp =10.0.1
+  - abseil-cpp =20230802.1
+  - libabseil-static =20230802.1=cxx17*
   license: Apache-2.0
-  license_family: APACHE
-  size: 27264456
-  timestamp: 1690570475633
-- platform: osx-arm64
-  name: libarrow
-  version: 10.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - aws-crt-cpp >=0.24.8,<0.24.9.0a0
-  - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - gflags >=2.2.2,<2.3.0a0
-  - glog >=0.6.0,<0.7.0a0
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libbrotlidec >=1.1.0,<1.2.0a0
-  - libbrotlienc >=1.1.0,<1.2.0a0
-  - libcxx >=14.0.6
-  - libgoogle-cloud >=2.12.0,<2.13.0a0
-  - libgrpc >=1.59.3,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  - libre2-11 >=2023.6.2,<2024.0a0
-  - libthrift >=0.19.0,<0.19.1.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.2.0,<4.0a0
-  - orc >=1.9.2,<1.9.3.0a0
-  - re2
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-10.0.1-h9be0040_57_cpu.conda
-  hash:
-    md5: 5091689e61bcf697cd14433d8f043c12
-    sha256: bae91a2d23ce8f96256d1bed684a490c3e6e14402b0f05689c7235c1a73c98f1
-  build: h9be0040_57_cpu
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 57
-  constrains:
-  - parquet-cpp <0.0a0
-  - arrow-cpp =10.0.1
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 16916203
-  timestamp: 1701295539102
-- platform: osx-arm64
+  license_family: Apache
+  size: 1263396
+  timestamp: 1695063868515
+- kind: conda
   name: libass
   version: 0.17.1
-  category: main
-  manager: conda
-  dependencies:
+  build: hf7da4fe_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
+  sha256: 31b17bebadd114c6c3e4a647245888fd83ec93533b6ee8f6bfca0bbbc3a95c35
+  md5: 53fff6fc379154382f5121325c5fe2f5
+  depends:
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
@@ -3896,944 +2773,369 @@ package:
   - harfbuzz >=8.1.1,<9.0a0
   - libexpat >=2.5.0,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
-  hash:
-    md5: 53fff6fc379154382f5121325c5fe2f5
-    sha256: 31b17bebadd114c6c3e4a647245888fd83ec93533b6ee8f6bfca0bbbc3a95c35
-  build: hf7da4fe_1
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
+  platform: osx
   license: ISC
   license_family: OTHER
   size: 110763
   timestamp: 1693027364342
-- platform: linux-64
+- kind: conda
   name: libblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - mkl >=2023.2.0,<2024.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_mkl.conda
-  hash:
-    md5: 8bf521f6007b0b0eb91515a1165b5d85
-    sha256: 9e5f27fca79223a5d38ccdf4c468e798c3684ba01bdb6b4b44e61f2103a298eb
   build: 20_linux64_mkl
-  arch: x86_64
-  subdir: linux-64
   build_number: 20
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-20_linux64_mkl.conda
+  sha256: 9e5f27fca79223a5d38ccdf4c468e798c3684ba01bdb6b4b44e61f2103a298eb
+  md5: 8bf521f6007b0b0eb91515a1165b5d85
+  depends:
+  - mkl >=2023.2.0,<2024.0a0
   constrains:
   - libcblas 3.9.0 20_linux64_mkl
   - blas * mkl
   - liblapack 3.9.0 20_linux64_mkl
   - liblapacke 3.9.0 20_linux64_mkl
-  track_features: blas_mkl
+  arch: x86_64
+  platform: linux
+  track_features:
+  - blas_mkl
   license: BSD-3-Clause
   license_family: BSD
   size: 14912
   timestamp: 1700568380170
-- platform: osx-arm64
+- kind: conda
   name: libblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
+  build: 20_osxarm64_openblas
+  build_number: 20
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-20_osxarm64_openblas.conda
+  sha256: 5b5b8394352c8ca06b15dcc9319d0af3e9f1dc03fc0a6f6deef05d664d6b763a
+  md5: 49bc8dec26663241ee064b2d7116ec2d
+  depends:
   - libopenblas >=0.3.25,<0.3.26.0a0
   - libopenblas >=0.3.25,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-20_osxarm64_openblas.conda
-  hash:
-    md5: 49bc8dec26663241ee064b2d7116ec2d
-    sha256: 5b5b8394352c8ca06b15dcc9319d0af3e9f1dc03fc0a6f6deef05d664d6b763a
-  build: 20_osxarm64_openblas
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 20
   constrains:
   - liblapack 3.9.0 20_osxarm64_openblas
   - liblapacke 3.9.0 20_osxarm64_openblas
   - libcblas 3.9.0 20_osxarm64_openblas
   - blas * openblas
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14722
   timestamp: 1700568881837
-- platform: linux-64
-  name: libbrotlicommon
-  version: 1.0.9
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.0.9-h166bdaf_9.conda
-  hash:
-    md5: 61641e239f96eae2b8492dc7e755828c
-    sha256: fc57c0876695c5b4ab7173438580c1d7eaa7dccaf14cb6467ca9e0e97abe0cf0
-  build: h166bdaf_9
-  arch: x86_64
-  subdir: linux-64
-  build_number: 9
-  license: MIT
-  license_family: MIT
-  size: 71065
-  timestamp: 1687884232329
-- platform: osx-arm64
-  name: libbrotlicommon
-  version: 1.1.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
-  hash:
-    md5: cd68f024df0304be41d29a9088162b02
-    sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
-  build: hb547adb_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 68579
-  timestamp: 1695990426128
-- platform: linux-64
-  name: libbrotlidec
-  version: 1.0.9
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlicommon 1.0.9 h166bdaf_9
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_9.conda
-  hash:
-    md5: 081aa22f4581c08e4372b0b6c2f8478e
-    sha256: 564f301430c3c61bc5e149e74157ec181ed2a758befc89f7c38466d515a0f614
-  build: h166bdaf_9
-  arch: x86_64
-  subdir: linux-64
-  build_number: 9
-  license: MIT
-  license_family: MIT
-  size: 32567
-  timestamp: 1687884247423
-- platform: osx-arm64
-  name: libbrotlidec
-  version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlicommon 1.1.0 hb547adb_1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
-  hash:
-    md5: ee1a519335cc10d0ec7e097602058c0a
-    sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
-  build: hb547adb_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 28928
-  timestamp: 1695990463780
-- platform: linux-64
-  name: libbrotlienc
-  version: 1.0.9
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlicommon 1.0.9 h166bdaf_9
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_9.conda
-  hash:
-    md5: 1f0a03af852a9659ed2bf08f2f1704fd
-    sha256: d27bc2562ea3f3b2bfd777f074f1cac6bfa4a737233dad288cd87c4634a9bb3a
-  build: h166bdaf_9
-  arch: x86_64
-  subdir: linux-64
-  build_number: 9
-  license: MIT
-  license_family: MIT
-  size: 265202
-  timestamp: 1687884262352
-- platform: osx-arm64
-  name: libbrotlienc
-  version: 1.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libbrotlicommon 1.1.0 hb547adb_1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
-  hash:
-    md5: d7e077f326a98b2cc60087eaff7c730b
-    sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
-  build: hb547adb_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 280943
-  timestamp: 1695990509392
-- platform: linux-64
-  name: libcap
-  version: '2.67'
-  category: main
-  manager: conda
-  dependencies:
-  - attr >=2.5.1,<2.6.0a0
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.67-he9d0100_0.conda
-  hash:
-    md5: d05556c80caffff164d17bdea0105a1a
-    sha256: 4dcf2290b9b90ad2654fbfff52e9c1d49885ce71f0bb853520e2b9d54809605b
-  build: he9d0100_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 99032
-  timestamp: 1675412183349
-- platform: linux-64
+- kind: conda
   name: libcblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas 3.9.0 20_linux64_mkl
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_mkl.conda
-  hash:
-    md5: 7a2972758a03adc92d856072c71c9170
-    sha256: 841b4d44e20e5207f4a74ca98176629ead5ba590384ed6b0fe3c8600248c9fef
   build: 20_linux64_mkl
-  arch: x86_64
-  subdir: linux-64
   build_number: 20
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-20_linux64_mkl.conda
+  sha256: 841b4d44e20e5207f4a74ca98176629ead5ba590384ed6b0fe3c8600248c9fef
+  md5: 7a2972758a03adc92d856072c71c9170
+  depends:
+  - libblas 3.9.0 20_linux64_mkl
   constrains:
   - blas * mkl
   - liblapack 3.9.0 20_linux64_mkl
   - liblapacke 3.9.0 20_linux64_mkl
-  track_features: blas_mkl
+  arch: x86_64
+  platform: linux
+  track_features:
+  - blas_mkl
   license: BSD-3-Clause
   license_family: BSD
   size: 14394
   timestamp: 1700568407268
-- platform: osx-arm64
+- kind: conda
   name: libcblas
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas 3.9.0 20_osxarm64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-20_osxarm64_openblas.conda
-  hash:
-    md5: 89f4718753c08afe8cda4dd5791ba94c
-    sha256: d3a74638f60e034202e373cf2950c69a8d831190d497881d13cbf789434d2489
   build: 20_osxarm64_openblas
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 20
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-20_osxarm64_openblas.conda
+  sha256: d3a74638f60e034202e373cf2950c69a8d831190d497881d13cbf789434d2489
+  md5: 89f4718753c08afe8cda4dd5791ba94c
+  depends:
+  - libblas 3.9.0 20_osxarm64_openblas
   constrains:
   - liblapack 3.9.0 20_osxarm64_openblas
   - liblapacke 3.9.0 20_osxarm64_openblas
   - blas * openblas
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14642
   timestamp: 1700568912840
-- platform: linux-64
-  name: libclang
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libclang13 15.0.7 default_ha2b6cf4_4
-  - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_hb11cfb5_4.conda
-  hash:
-    md5: c90f4cbb57839c98fef8f830e4b9972f
-    sha256: 0b80441f222a91074d0e5edb0fbc3b1ce16ca2cdf6ab899721afdcc3a3ff6302
-  build: default_hb11cfb5_4
-  arch: x86_64
-  subdir: linux-64
-  build_number: 4
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 133384
-  timestamp: 1701412265788
-- platform: linux-64
-  name: libclang13
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libllvm15 >=15.0.7,<15.1.0a0
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_ha2b6cf4_4.conda
-  hash:
-    md5: 898e0dd993afbed0d871b60c2eb33b83
-    sha256: e1d34d415160b69a401dc0662bf1b5378655193ed1364bf7dd14f055e76e4b60
-  build: default_ha2b6cf4_4
-  arch: x86_64
-  subdir: linux-64
-  build_number: 4
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 9581845
-  timestamp: 1701412208888
-- platform: linux-64
-  name: libcrc32c
-  version: 1.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.4.0
-  - libstdcxx-ng >=9.4.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
-  hash:
-    md5: c965a5aa0d5c1c37ffc62dff36e28400
-    sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
-  build: h9c3ff4c_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 20440
-  timestamp: 1633683576494
-- platform: osx-arm64
-  name: libcrc32c
-  version: 1.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=11.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
-  hash:
-    md5: 32bd82a6a625ea6ce090a81c3d34edeb
-    sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
-  build: hbdafb3b_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18765
-  timestamp: 1633683992603
-- platform: linux-64
+- kind: conda
   name: libcublas
   version: 11.10.3.66
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/libcublas-11.10.3.66-0.tar.bz2
-  hash:
-    md5: 1d3211d2deb549b84f6fdaf96f7cbb88
-    sha256: 14c30da20a9c1519ec5358f493222913ede2fa1048b9c65cfdf29e4c1df4b057
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/libcublas-11.10.3.66-0.tar.bz2
+  sha256: 14c30da20a9c1519ec5358f493222913ede2fa1048b9c65cfdf29e4c1df4b057
+  md5: 1d3211d2deb549b84f6fdaf96f7cbb88
+  arch: x86_64
+  platform: linux
   size: 299985410
   timestamp: 1653020021295
-- platform: linux-64
+- kind: conda
   name: libcufft
   version: 10.7.2.124
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/libcufft-10.7.2.124-h4fbf590_0.tar.bz2
-  hash:
-    md5: dc69f1daa40372e9b869064ab926ee26
-    sha256: cd57e77ca3ec6aee4dc0915fc0db96091a0b7600f130a57ac24a05ff0bfce832
   build: h4fbf590_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/libcufft-10.7.2.124-h4fbf590_0.tar.bz2
+  sha256: cd57e77ca3ec6aee4dc0915fc0db96091a0b7600f130a57ac24a05ff0bfce832
+  md5: dc69f1daa40372e9b869064ab926ee26
+  arch: x86_64
+  platform: linux
   size: 98119711
   timestamp: 1646799908932
-- platform: linux-64
+- kind: conda
   name: libcufile
   version: 1.8.1.2
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.8.1.2-0.tar.bz2
-  hash:
-    md5: 9216c3ab5eb551bb7c2c4f604b4e7614
-    sha256: f399e21e2d8a286d74354c0df94635f259cfb6649031a8f48a5654f97387014f
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/libcufile-1.8.1.2-0.tar.bz2
+  sha256: f399e21e2d8a286d74354c0df94635f259cfb6649031a8f48a5654f97387014f
+  md5: 9216c3ab5eb551bb7c2c4f604b4e7614
+  arch: x86_64
+  platform: linux
   size: 1056957
   timestamp: 1698278222739
-- platform: linux-64
-  name: libcups
-  version: 2.3.3
-  category: main
-  manager: conda
-  dependencies:
-  - krb5 >=1.20.1,<1.21.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h36d4200_3.conda
-  hash:
-    md5: c9f4416a34bc91e0eb029f912c68f81f
-    sha256: 0ccd610207807f53328f137b2adc99c413f8e1dcd1302f0325412796a94eaaf7
-  build: h36d4200_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  license: Apache-2.0
-  license_family: Apache
-  size: 4519779
-  timestamp: 1671148111233
-- platform: linux-64
+- kind: conda
   name: libcurand
   version: 10.3.4.101
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.4.101-0.tar.bz2
-  hash:
-    md5: c19aee1cc95a33b3aadc62113f1e57f2
-    sha256: 0c001fd158a81b5fff10cd711805f87c8d11a9f5794ea9fa5aa76aef129c0b48
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/libcurand-10.3.4.101-0.tar.bz2
+  sha256: 0c001fd158a81b5fff10cd711805f87c8d11a9f5794ea9fa5aa76aef129c0b48
+  md5: c19aee1cc95a33b3aadc62113f1e57f2
+  arch: x86_64
+  platform: linux
   size: 54298628
   timestamp: 1698747381363
-- platform: linux-64
-  name: libcurl
-  version: 8.1.2
-  category: main
-  manager: conda
-  dependencies:
-  - krb5 >=1.20.1,<1.21.0a0
-  - libgcc-ng >=12
-  - libnghttp2 >=1.52.0,<2.0a0
-  - libssh2 >=1.10.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.0,<4.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.1.2-h409715c_0.conda
-  hash:
-    md5: 50c873c9660ed116707ae15b663928d8
-    sha256: d572c31ff48d2db6ca5bab476bf325811cfc82577480b3791487c3fe7bff2ffa
-  build: h409715c_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: curl
-  license_family: MIT
-  size: 372833
-  timestamp: 1685447685782
-- platform: osx-arm64
-  name: libcurl
-  version: 8.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.5.0-h2d989ff_0.conda
-  hash:
-    md5: f1211ed00947a84e15a964a8f459f620
-    sha256: f1c04be217aaf161ce3c99a8d618871295b5dc1eae2f7ff7b32078af50303f5b
-  build: h2d989ff_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: curl
-  license_family: MIT
-  size: 350298
-  timestamp: 1701860532373
-- platform: linux-64
+- kind: conda
   name: libcusolver
   version: 11.4.0.1
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/libcusolver-11.4.0.1-0.tar.bz2
-  hash:
-    md5: c4de49e8b2f01065962f2fec81fb7058
-    sha256: fbcd211720e29bdb8a42a4360de6d73c2c6cc44040bedefc45c9a8ffb1f906c0
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/libcusolver-11.4.0.1-0.tar.bz2
+  sha256: fbcd211720e29bdb8a42a4360de6d73c2c6cc44040bedefc45c9a8ffb1f906c0
+  md5: c4de49e8b2f01065962f2fec81fb7058
+  arch: x86_64
+  platform: linux
   size: 82550774
   timestamp: 1653019043877
-- platform: linux-64
+- kind: conda
   name: libcusparse
   version: 11.7.4.91
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/libcusparse-11.7.4.91-0.tar.bz2
-  hash:
-    md5: 9ca85f813fbc5e8b811a1ad4ca451911
-    sha256: c0b0684bc8ad02af7a91506533203eb68467d6ad1fbf3be4aacaa9aa39c89a3b
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/libcusparse-11.7.4.91-0.tar.bz2
+  sha256: c0b0684bc8ad02af7a91506533203eb68467d6ad1fbf3be4aacaa9aa39c89a3b
+  md5: 9ca85f813fbc5e8b811a1ad4ca451911
+  arch: x86_64
+  platform: linux
   size: 158486709
   timestamp: 1653019415058
-- platform: osx-arm64
+- kind: conda
   name: libcxx
   version: 16.0.6
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
-  hash:
-    md5: 9d7d724faf0413bf1dbc5a85935700c8
-    sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
   build: h4653b0c_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+  sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
+  md5: 9d7d724faf0413bf1dbc5a85935700c8
+  arch: aarch64
+  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 1160232
   timestamp: 1686896993785
-- platform: linux-64
-  name: libdb
-  version: 6.2.32
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  - libstdcxx-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdb-6.2.32-h9c3ff4c_0.tar.bz2
-  hash:
-    md5: 3f3258d8f841fbac63b36b75bdac1afd
-    sha256: 21fac1012ff05b131d4b5d284003dbbe7b5c4c652aa9e401b46279ed5a784372
-  build: h9c3ff4c_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: AGPL-3.0-only
-  license_family: AGPL
-  size: 24409456
-  timestamp: 1609539093147
-- platform: linux-64
+- kind: conda
   name: libdeflate
   version: '1.17'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.17-h0b41bf4_0.conda
-  hash:
-    md5: 5cc781fd91968b11a8a7fdbee0982676
-    sha256: f9983a8ea03531f2c14bce76c870ca325c0fddf0c4e872bff1f78bc52624179c
   build: h0b41bf4_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.17-h0b41bf4_0.conda
+  sha256: f9983a8ea03531f2c14bce76c870ca325c0fddf0c4e872bff1f78bc52624179c
+  md5: 5cc781fd91968b11a8a7fdbee0982676
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
   size: 65017
   timestamp: 1673785897585
-- platform: osx-arm64
+- kind: conda
   name: libdeflate
   version: '1.17'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.17-h1a8c8d9_0.conda
-  hash:
-    md5: cae34d3f6ab02e0abf92ec3caaf0bd39
-    sha256: 9a1979b3f6dc155b8c48987cfae6b13ba19b3e176e4470b87f60011e806218f5
   build: h1a8c8d9_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.17-h1a8c8d9_0.conda
+  sha256: 9a1979b3f6dc155b8c48987cfae6b13ba19b3e176e4470b87f60011e806218f5
+  md5: cae34d3f6ab02e0abf92ec3caaf0bd39
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 48222
   timestamp: 1673786109437
-- platform: linux-64
-  name: libedit
-  version: 3.1.20191231
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  - ncurses >=6.2,<7.0.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
-  hash:
-    md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
-    sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
-  build: he28a2e2_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 123878
-  timestamp: 1597616541093
-- platform: osx-arm64
-  name: libedit
-  version: 3.1.20191231
-  category: main
-  manager: conda
-  dependencies:
-  - ncurses >=6.2,<7.0.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
-  hash:
-    md5: 30e4362988a2623e9eb34337b83e01f9
-    sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
-  build: hc8eb9b7_2
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 96607
-  timestamp: 1597616630749
-- platform: linux-64
-  name: libev
-  version: '4.33'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
-  hash:
-    md5: 172bf1cd1ff8629f2b1179945ed45055
-    sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
-  build: hd590300_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 112766
-  timestamp: 1702146165126
-- platform: osx-arm64
-  name: libev
-  version: '4.33'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
-  hash:
-    md5: 36d33e440c31857372a72137f78bacf5
-    sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
-  build: h93a5062_2
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 107458
-  timestamp: 1702146414478
-- platform: linux-64
-  name: libevent
-  version: 2.1.10
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.4.0
-  - openssl >=3.0.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.10-h28343ad_4.tar.bz2
-  hash:
-    md5: 4a049fc560e00e43151dc51368915fdd
-    sha256: 31ac7124c92628cd1c6bea368e38d7f43f8ec68d88128ecdc177773e6d00c60a
-  build: h28343ad_4
-  arch: x86_64
-  subdir: linux-64
-  build_number: 4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1169108
-  timestamp: 1633489266107
-- platform: osx-arm64
-  name: libevent
-  version: 2.1.12
-  category: main
-  manager: conda
-  dependencies:
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
-  hash:
-    md5: 1a109764bff3bdc7bdd84088347d71dc
-    sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
-  build: h2757513_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 368167
-  timestamp: 1685726248899
-- platform: linux-64
+- kind: conda
   name: libexpat
   version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
-  hash:
-    md5: 6305a3dd2752c76335295da4e581f2fd
-    sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
-  build: hcb278e6_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  constrains:
-  - expat 2.5.0.*
-  license: MIT
-  license_family: MIT
-  size: 77980
-  timestamp: 1680190528313
-- platform: osx-arm64
-  name: libexpat
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
-  hash:
-    md5: 5a097ad3d17e42c148c9566280481317
-    sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
   build: hb7217d7_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+  sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
+  md5: 5a097ad3d17e42c148c9566280481317
   constrains:
   - expat 2.5.0.*
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 63442
   timestamp: 1680190916539
-- platform: linux-64
+- kind: conda
   name: libffi
   version: 3.4.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.4.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
-  hash:
-    md5: d645c6d2ac96843a2bfaccd2d62b3ac3
-    sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
-  build: h7f98852_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  license: MIT
-  license_family: MIT
-  size: 58292
-  timestamp: 1636488182923
-- platform: osx-arm64
-  name: libffi
-  version: 3.4.2
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
-  hash:
-    md5: 086914b672be056eb70fd4285b6783b6
-    sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
   build: h3422bc3_5
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 39020
   timestamp: 1636488587153
-- platform: linux-64
-  name: libflac
-  version: 1.4.3
-  category: main
-  manager: conda
-  dependencies:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - libogg 1.3.*
-  - libogg >=1.3.4,<1.4.0a0
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
-  hash:
-    md5: ee48bf17cc83a00f59ca1494d5646869
-    sha256: 65908b75fa7003167b8a8f0001e11e58ed5b1ef5e98b96ab2ba66d7c1b822c7d
-  build: h59595ed_0
-  arch: x86_64
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h7f98852_5
+  build_number: 5
   subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 394383
-  timestamp: 1687765514062
-- platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+  sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+  md5: d645c6d2ac96843a2bfaccd2d62b3ac3
+  depends:
+  - libgcc-ng >=9.4.0
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 58292
+  timestamp: 1636488182923
+- kind: conda
   name: libgcc-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h807b86a_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
+  sha256: 5e88f658e07a30ab41b154b42c59f079b168acfa9551a75bdc972099453f4105
+  md5: 23fdf1fef05baeb7eadc2aed5fb0011f
+  depends:
   - _libgcc_mutex 0.1 conda_forge
   - _openmp_mutex >=4.5
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
-  hash:
-    md5: 23fdf1fef05baeb7eadc2aed5fb0011f
-    sha256: 5e88f658e07a30ab41b154b42c59f079b168acfa9551a75bdc972099453f4105
-  build: h807b86a_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
   constrains:
   - libgomp 13.2.0 h807b86a_3
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 773629
   timestamp: 1699753612541
-- platform: linux-64
-  name: libgcrypt
-  version: 1.10.3
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libgpg-error >=1.47,<2.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
-  hash:
-    md5: 32d16ad533c59bb0a3c5ffaf16110829
-    sha256: d1bd47faa29fec7288c7b212198432b07f890d3d6f646078da93b059c2e9daff
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.1-or-later AND GPL-2.0-or-later
-  license_family: GPL
-  size: 634887
-  timestamp: 1701383493365
-- platform: osx-arm64
+- kind: conda
   name: libgfortran
   version: 5.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgfortran5 13.2.0 hf226fd6_1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
-  hash:
-    md5: 1ad37a5c60c250bb2b4a9f75563e181c
-    sha256: bc8750e7893e693fa380bf2f342d4a5ce44995467cbdf72e56a00e5106b4892d
   build: 13_2_0_hd922786_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+  sha256: bc8750e7893e693fa380bf2f342d4a5ce44995467cbdf72e56a00e5106b4892d
+  md5: 1ad37a5c60c250bb2b4a9f75563e181c
+  depends:
+  - libgfortran5 13.2.0 hf226fd6_1
+  arch: aarch64
+  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 110095
   timestamp: 1694172198016
-- platform: linux-64
+- kind: conda
   name: libgfortran-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgfortran5 13.2.0 ha4646dd_3
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_3.conda
-  hash:
-    md5: 73031c79546ad06f1fe62e57fdd021bc
-    sha256: 5b918950b84605b6865de438757f507b1eff73c96fd562f7022c80028b088c14
   build: h69a702a_3
-  arch: x86_64
-  subdir: linux-64
   build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_3.conda
+  sha256: 5b918950b84605b6865de438757f507b1eff73c96fd562f7022c80028b088c14
+  md5: 73031c79546ad06f1fe62e57fdd021bc
+  depends:
+  - libgfortran5 13.2.0 ha4646dd_3
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 23837
   timestamp: 1699753845201
-- platform: linux-64
+- kind: conda
   name: libgfortran5
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_3.conda
-  hash:
-    md5: c714d905cdfa0e70200f68b80cc04764
-    sha256: 0084a1d29a4f8ee3b8edad80eb6c42e5f0480f054f28cf713fb314bebb347a50
   build: ha4646dd_3
-  arch: x86_64
-  subdir: linux-64
   build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_3.conda
+  sha256: 0084a1d29a4f8ee3b8edad80eb6c42e5f0480f054f28cf713fb314bebb347a50
+  md5: c714d905cdfa0e70200f68b80cc04764
+  depends:
+  - libgcc-ng >=13.2.0
   constrains:
   - libgfortran-ng 13.2.0
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 1436929
   timestamp: 1699753630186
-- platform: osx-arm64
+- kind: conda
   name: libgfortran5
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - llvm-openmp >=8.0.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
-  hash:
-    md5: 4480d71b98c87faafab132d33e23135e
-    sha256: cb9cb11e49a6a8466ea7556a723080d3aeefd556df9b444b941afc5b54368b22
   build: hf226fd6_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+  sha256: cb9cb11e49a6a8466ea7556a723080d3aeefd556df9b444b941afc5b54368b22
+  md5: 4480d71b98c87faafab132d33e23135e
+  depends:
+  - llvm-openmp >=8.0.0
   constrains:
   - libgfortran 5.0.0 13_2_0_*_1
+  arch: aarch64
+  platform: osx
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 995733
   timestamp: 1694172076009
-- platform: linux-64
+- kind: conda
   name: libglib
   version: 2.78.3
-  category: main
-  manager: conda
-  dependencies:
-  - gettext >=0.21.1,<1.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.42,<10.43.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.3-h783c2da_0.conda
-  hash:
-    md5: 9bd06b12bbfa6fd1740fd23af4b0f0c7
-    sha256: b1b594294a0fe4c9a51596ef027efed9268d60827e8ae61fb7545c521a631e33
-  build: h783c2da_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - glib 2.78.3 *_0
-  license: LGPL-2.1-or-later
-  size: 2696351
-  timestamp: 1702003069863
-- platform: osx-arm64
-  name: libglib
-  version: 2.78.3
-  category: main
-  manager: conda
-  dependencies:
+  build: hb438215_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.3-hb438215_0.conda
+  sha256: f26afb1003e810e768138b0c849e9408c0ae8635062aeaf7abae381903a84e53
+  md5: 8c98b7018b434236e2c0f14d7cf3c113
+  depends:
   - __osx >=10.9
   - gettext >=0.21.1,<1.0a0
   - libcxx >=16.0.6
@@ -4841,892 +3143,446 @@ package:
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - pcre2 >=10.42,<10.43.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.3-hb438215_0.conda
-  hash:
-    md5: 8c98b7018b434236e2c0f14d7cf3c113
-    sha256: f26afb1003e810e768138b0c849e9408c0ae8635062aeaf7abae381903a84e53
-  build: hb438215_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
   constrains:
   - glib 2.78.3 *_0
+  arch: aarch64
+  platform: osx
   license: LGPL-2.1-or-later
   size: 2452441
   timestamp: 1702003179895
-- platform: linux-64
-  name: libgoogle-cloud
-  version: 2.12.0
-  category: main
-  manager: conda
-  dependencies:
-  - libabseil * cxx17*
-  - libabseil >=20230125.3,<20230126.0a0
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.1.2,<9.0a0
-  - libgcc-ng >=12
-  - libgrpc >=1.56.0,<1.57.0a0
-  - libprotobuf >=4.23.3,<4.23.4.0a0
-  - libstdcxx-ng >=12
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h840a212_1.conda
-  hash:
-    md5: 03c225a73835f5aa68c13e62eb360406
-    sha256: 18d9050dced23e4b3a1e5f77956d11ef8d98bb34e007647de5a1aa0e2c099bc9
-  build: h840a212_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  constrains:
-  - google-cloud-cpp 2.12.0 *_1
-  license: Apache-2.0
-  license_family: Apache
-  size: 46106632
-  timestamp: 1688284832753
-- platform: osx-arm64
-  name: libgoogle-cloud
-  version: 2.12.0
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - libabseil * cxx17*
-  - libabseil >=20230802.1,<20230803.0a0
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libcxx >=16.0.6
-  - libgrpc >=1.59.2,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-hfb399a7_4.conda
-  hash:
-    md5: d62901188ab756c841cbb9a80c6c3f3c
-    sha256: 22122939a462f64a82ca2f305c43e5e5cf5a55f1ae12979c2445f9dc196b7047
-  build: hfb399a7_4
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 4
-  constrains:
-  - google-cloud-cpp 2.12.0 *_4
-  license: Apache-2.0
-  license_family: Apache
-  size: 31440327
-  timestamp: 1698982048456
-- platform: linux-64
-  name: libgpg-error
-  version: '1.47'
-  category: main
-  manager: conda
-  dependencies:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.47-h71f35ed_0.conda
-  hash:
-    md5: c2097d0b46367996f09b4e8e4920384a
-    sha256: 0306b3c2d65863048983a50bd8b86f6f26e457ef55d1da745a5796af25093f5a
-  build: h71f35ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: GPL-2.0-only
-  license_family: GPL
-  size: 260794
-  timestamp: 1686979818648
-- platform: linux-64
-  name: libgrpc
-  version: 1.56.2
-  category: main
-  manager: conda
-  dependencies:
-  - c-ares >=1.19.1,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20230125.3,<20230126.0a0
-  - libgcc-ng >=12
-  - libprotobuf >=4.23.3,<4.23.4.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.2,<4.0a0
-  - re2 >=2023.3.2,<2023.3.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.56.2-h3905398_1.conda
-  hash:
-    md5: 0b01e6ff8002994bd4ddbffcdbec7856
-    sha256: 587c14bd5969d49f3a0a94dd933efbeabe77864319306d91714905b5caa5aa35
-  build: h3905398_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  constrains:
-  - grpc-cpp =1.56.2
-  license: Apache-2.0
-  license_family: APACHE
-  size: 6331805
-  timestamp: 1692023574803
-- platform: osx-arm64
+- kind: conda
   name: libgrpc
   version: 1.59.3
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
+  build: hd6c4280_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.59.3-hd6c4280_0.conda
+  sha256: 3f95a2792e565b628cb284de92017a37a1cddc4a3f83453b8f75d9adc9f8cfdd
+  md5: 896c137eaf0c22f2fef58332eb4a4b83
+  depends:
   - c-ares >=1.21.0,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=16.0.6
+  - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
+  - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.4,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.59.3-hbcf6334_0.conda
-  hash:
-    md5: e9c7cbc84af929dd47501629a5e19713
-    sha256: 54cacd1fc7503d48c135301a775568f15089b537b3c56804767c627a89a20c30
-  build: hbcf6334_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
   constrains:
   - grpc-cpp =1.59.3
   license: Apache-2.0
   license_family: APACHE
-  size: 3950361
-  timestamp: 1700260902499
-- platform: linux-64
+  size: 6600132
+  timestamp: 1700259627150
+- kind: conda
+  name: libgrpc
+  version: 1.60.0
+  build: hfc68871_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.60.0-hfc68871_0.conda
+  sha256: bbfb0f9c3e12047cf83557930b126ac3354bad6f787f27d4312fb8c5cd2660de
+  md5: 3a7cc6e5bdb46d91a9e10c91cdadd3a2
+  depends:
+  - c-ares >=1.25.0,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=15
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.0,<4.0a0
+  - re2
+  constrains:
+  - grpc-cpp =1.60.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4106240
+  timestamp: 1705976961550
+- kind: conda
   name: libhwloc
   version: 2.9.1
-  category: main
-  manager: conda
-  dependencies:
+  build: hd6dc26d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.1-hd6dc26d_0.conda
+  sha256: 39bb53aa6ae0cab734568a58ad31ffe82ea244a82f575cd5c67abba785e442ee
+  md5: a3ede1b8e47f993ff1fe3908b23bb307
+  depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libxml2 >=2.10.3,<2.11.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.1-hd6dc26d_0.conda
-  hash:
-    md5: a3ede1b8e47f993ff1fe3908b23bb307
-    sha256: 39bb53aa6ae0cab734568a58ad31ffe82ea244a82f575cd5c67abba785e442ee
-  build: hd6dc26d_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 2569104
   timestamp: 1680713440274
-- platform: linux-64
+- kind: conda
   name: libiconv
   version: '1.17'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_1.conda
-  hash:
-    md5: 4b06b43d0eca61db2899e4d7a289c302
-    sha256: a9364735ef2542558ed59aa5f404707dab674df465cbdf312edeaf5e827b55ed
-  build: hd590300_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: LGPL-2.1-only
-  size: 692542
-  timestamp: 1702300152310
-- platform: osx-arm64
-  name: libiconv
-  version: '1.17'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_1.conda
-  hash:
-    md5: df3fbfc1fddc8fa40122206a4e47ea4e
-    sha256: d407ebd1e72ebb20716ea325cdebdd018bdc3c3d3424e67825db3eaa8809164e
   build: h0d3ecfb_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-h0d3ecfb_1.conda
+  sha256: d407ebd1e72ebb20716ea325cdebdd018bdc3c3d3424e67825db3eaa8809164e
+  md5: df3fbfc1fddc8fa40122206a4e47ea4e
+  arch: aarch64
+  platform: osx
   license: LGPL-2.1-only
   size: 652683
   timestamp: 1702300285138
-- platform: osx-arm64
+- kind: conda
+  name: libiconv
+  version: '1.17'
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_1.conda
+  sha256: a9364735ef2542558ed59aa5f404707dab674df465cbdf312edeaf5e827b55ed
+  md5: 4b06b43d0eca61db2899e4d7a289c302
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: LGPL-2.1-only
+  size: 692542
+  timestamp: 1702300152310
+- kind: conda
   name: libidn2
   version: 2.3.4
-  category: main
-  manager: conda
-  dependencies:
+  build: h1a8c8d9_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.4-h1a8c8d9_0.tar.bz2
+  sha256: 3f2990c33c57559fbf03c5e5b3f3c8e95886548ab4c7fc10314e4514d6632703
+  md5: 7fdc11b6fd3ea4ce92886df855fc7085
+  depends:
   - gettext >=0.21.1,<1.0a0
   - libunistring >=0,<1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.4-h1a8c8d9_0.tar.bz2
-  hash:
-    md5: 7fdc11b6fd3ea4ce92886df855fc7085
-    sha256: 3f2990c33c57559fbf03c5e5b3f3c8e95886548ab4c7fc10314e4514d6632703
-  build: h1a8c8d9_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: LGPLv2
   size: 173494
   timestamp: 1666574243937
-- platform: linux-64
+- kind: conda
   name: liblapack
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas 3.9.0 20_linux64_mkl
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_mkl.conda
-  hash:
-    md5: 4db0cd03efcdab535f6f066aca4cddbb
-    sha256: 21b4324dd65815f6b5a83c15f0b9a201434d0aa55eeecc37efce7ee70bbbf482
   build: 20_linux64_mkl
-  arch: x86_64
-  subdir: linux-64
   build_number: 20
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-20_linux64_mkl.conda
+  sha256: 21b4324dd65815f6b5a83c15f0b9a201434d0aa55eeecc37efce7ee70bbbf482
+  md5: 4db0cd03efcdab535f6f066aca4cddbb
+  depends:
+  - libblas 3.9.0 20_linux64_mkl
   constrains:
   - libcblas 3.9.0 20_linux64_mkl
   - blas * mkl
   - liblapacke 3.9.0 20_linux64_mkl
-  track_features: blas_mkl
+  arch: x86_64
+  platform: linux
+  track_features:
+  - blas_mkl
   license: BSD-3-Clause
   license_family: BSD
   size: 14437
   timestamp: 1700568420776
-- platform: osx-arm64
+- kind: conda
   name: liblapack
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libblas 3.9.0 20_osxarm64_openblas
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-20_osxarm64_openblas.conda
-  hash:
-    md5: 1fefac78f2315455ce2d7f34782eac0a
-    sha256: e13f79828a7752f6e0a74cbe62df80c551285f6c37de86bc3bd9987c97faca57
   build: 20_osxarm64_openblas
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 20
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-20_osxarm64_openblas.conda
+  sha256: e13f79828a7752f6e0a74cbe62df80c551285f6c37de86bc3bd9987c97faca57
+  md5: 1fefac78f2315455ce2d7f34782eac0a
+  depends:
+  - libblas 3.9.0 20_osxarm64_openblas
   constrains:
   - liblapacke 3.9.0 20_osxarm64_openblas
   - libcblas 3.9.0 20_osxarm64_openblas
   - blas * openblas
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 14648
   timestamp: 1700568930669
-- platform: linux-64
+- kind: conda
   name: liblapacke
   version: 3.9.0
-  category: main
-  manager: conda
-  dependencies:
+  build: 20_linux64_mkl
+  build_number: 20
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-20_linux64_mkl.conda
+  sha256: 0e6ece3ff4b2088d30b5836771e87440840c643be0ab885a2605be002d566a34
+  md5: 3dea5e9be386b963d7f4368966e238b3
+  depends:
   - libblas 3.9.0 20_linux64_mkl
   - libcblas 3.9.0 20_linux64_mkl
   - liblapack 3.9.0 20_linux64_mkl
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-20_linux64_mkl.conda
-  hash:
-    md5: 3dea5e9be386b963d7f4368966e238b3
-    sha256: 0e6ece3ff4b2088d30b5836771e87440840c643be0ab885a2605be002d566a34
-  build: 20_linux64_mkl
-  arch: x86_64
-  subdir: linux-64
-  build_number: 20
   constrains:
   - blas * mkl
-  track_features: blas_mkl
+  arch: x86_64
+  platform: linux
+  track_features:
+  - blas_mkl
   license: BSD-3-Clause
   license_family: BSD
   size: 14402
   timestamp: 1700568434506
-- platform: linux-64
-  name: libllvm15
-  version: 15.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.10.3,<2.11.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hadd5161_1.conda
-  hash:
-    md5: 17d91085ccf5934ce652cb448d0cb65a
-    sha256: f649fac60cb122bf0d85c4955725d94c353fdbd768bcd44f0444979b363cc9ab
-  build: hadd5161_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 33016652
-  timestamp: 1678862492181
-- platform: linux-64
-  name: libnghttp2
-  version: 1.58.0
-  category: main
-  manager: conda
-  dependencies:
-  - c-ares >=1.21.0,<2.0a0
-  - libev >=4.33,<4.34.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_0.conda
-  hash:
-    md5: 9b13d5ee90fc9f09d54fd403247342b4
-    sha256: 151b18e4f92dcca263a6d23e4beb0c4e2287aa1c7d0587ff71ef50035ed34aca
-  build: h47da74e_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 631397
-  timestamp: 1699440427647
-- platform: osx-arm64
-  name: libnghttp2
-  version: 1.58.0
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - c-ares >=1.23.0,<2.0a0
-  - libcxx >=16.0.6
-  - libev >=4.33,<4.34.0a0
-  - libev >=4.33,<5.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
-  hash:
-    md5: 1813e066bfcef82de579a0be8a766df4
-    sha256: fc97aaaf0c6d0f508be313d86c2705b490998d382560df24be918b8e977802cd
-  build: ha4dd798_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: MIT
-  license_family: MIT
-  size: 565451
-  timestamp: 1702130473930
-- platform: linux-64
+- kind: conda
   name: libnpp
   version: 11.7.4.75
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/libnpp-11.7.4.75-0.tar.bz2
-  hash:
-    md5: 0a55ecd0b813fe5774ede297007e5413
-    sha256: 34091bd3ca4910ce5f7715637863a76f09739782090586dff9767f1632a631dd
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/libnpp-11.7.4.75-0.tar.bz2
+  sha256: 34091bd3ca4910ce5f7715637863a76f09739782090586dff9767f1632a631dd
+  md5: 0a55ecd0b813fe5774ede297007e5413
+  arch: x86_64
+  platform: linux
   size: 135594124
   timestamp: 1653019632350
-- platform: linux-64
+- kind: conda
   name: libnsl
   version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-  hash:
-    md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
-    sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   build: hd590300_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
+  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   size: 33408
   timestamp: 1697359010159
-- platform: linux-64
-  name: libnuma
-  version: 2.0.16
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.16-h0b41bf4_1.conda
-  hash:
-    md5: 28bfe2cb11357ccc5be21101a6b7ce86
-    sha256: 814a50cba215548ec3ebfb53033ffb9b3b070b2966570ff44910b8d9ba1c359d
-  build: h0b41bf4_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: LGPL-2.1-only
-  size: 41107
-  timestamp: 1676004391774
-- platform: linux-64
+- kind: conda
   name: libnvjpeg
   version: 11.8.0.2
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-11.8.0.2-0.tar.bz2
-  hash:
-    md5: 32a0a604688ee485878887ff4c086f77
-    sha256: bdd39dcb18ee6fcbd41fc4fa4b45c8e368abb18289fe164151d83080b8128eb5
   build: '0'
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/nvidia/linux-64/libnvjpeg-11.8.0.2-0.tar.bz2
+  sha256: bdd39dcb18ee6fcbd41fc4fa4b45c8e368abb18289fe164151d83080b8128eb5
+  md5: 32a0a604688ee485878887ff4c086f77
+  arch: x86_64
+  platform: linux
   size: 2337429
   timestamp: 1653015934015
-- platform: linux-64
-  name: libogg
-  version: 1.3.4
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
-  hash:
-    md5: 6e8cc2173440d77708196c5b93771680
-    sha256: b88afeb30620b11bed54dac4295aa57252321446ba4e6babd7dce4b9ffde9b25
-  build: h7f98852_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 210550
-  timestamp: 1610382007814
-- platform: osx-arm64
+- kind: conda
   name: libopenblas
   version: 0.3.25
-  category: main
-  manager: conda
-  dependencies:
+  build: openmp_h6c19121_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.25-openmp_h6c19121_0.conda
+  sha256: b112e0d500bc0314ea8d393efac3ab8c67857e5a2b345348c98e703ee92723e5
+  md5: a1843550403212b9dedeeb31466ade03
+  depends:
   - libgfortran 5.*
   - libgfortran5 >=12.3.0
   - llvm-openmp >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.25-openmp_h6c19121_0.conda
-  hash:
-    md5: a1843550403212b9dedeeb31466ade03
-    sha256: b112e0d500bc0314ea8d393efac3ab8c67857e5a2b345348c98e703ee92723e5
-  build: openmp_h6c19121_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
   constrains:
   - openblas >=0.3.25,<0.3.26.0a0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 2896390
   timestamp: 1700535987588
-- platform: linux-64
+- kind: conda
   name: libopus
   version: 1.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
-  hash:
-    md5: 15345e56d527b330e1cacbdf58676e8f
-    sha256: 0e1c2740ebd1c93226dc5387461bbcf8142c518f2092f3ea7551f77755decc8f
-  build: h7f98852_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 260658
-  timestamp: 1606823578035
-- platform: osx-arm64
-  name: libopus
-  version: 1.3.1
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
-  hash:
-    md5: 3d0dbee0ccd2f6d6781d270313627b62
-    sha256: e9912101a58cbc609a1917c5289f3bd1f600c82ed3a1c90a6dd4ca02df77958a
   build: h27ca646_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
+  sha256: e9912101a58cbc609a1917c5289f3bd1f600c82ed3a1c90a6dd4ca02df77958a
+  md5: 3d0dbee0ccd2f6d6781d270313627b62
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 252854
   timestamp: 1606823635137
-- platform: linux-64
+- kind: conda
   name: libpng
   version: 1.6.39
-  category: main
-  manager: conda
-  dependencies:
+  build: h753d276_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
+  sha256: a32b36d34e4f2490b99bddbc77d01a674d304f667f0e62c89e02c961addef462
+  md5: e1c890aebdebbfbf87e2c917187b4416
+  depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
-  hash:
-    md5: e1c890aebdebbfbf87e2c917187b4416
-    sha256: a32b36d34e4f2490b99bddbc77d01a674d304f667f0e62c89e02c961addef462
-  build: h753d276_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: zlib-acknowledgement
   size: 282599
   timestamp: 1669075729952
-- platform: osx-arm64
+- kind: conda
   name: libpng
   version: 1.6.39
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
-  hash:
-    md5: 0078e6327c13cfdeae6ff7601e360383
-    sha256: 21ab8409a8e66f9408b96428c0a36a9768faee9fe623c56614576f9e12962981
   build: h76d750c_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
+  sha256: 21ab8409a8e66f9408b96428c0a36a9768faee9fe623c56614576f9e12962981
+  md5: 0078e6327c13cfdeae6ff7601e360383
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
   license: zlib-acknowledgement
   size: 259412
   timestamp: 1669075883972
-- platform: linux-64
-  name: libpq
-  version: '15.3'
-  category: main
-  manager: conda
-  dependencies:
-  - krb5 >=1.20.1,<1.21.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.0,<3.2.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-15.3-hbcd7760_1.conda
-  hash:
-    md5: 8afb2a97d256ffde95b91a6283bc598c
-    sha256: 96031c853d1a8b32c50c04b791aa199508ab1f0fa879ab7fcce175ee24620f78
-  build: hbcd7760_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: PostgreSQL
-  size: 2530642
-  timestamp: 1684451981378
-- platform: linux-64
+- kind: conda
   name: libprotobuf
-  version: 4.23.3
-  category: main
-  manager: conda
-  dependencies:
+  version: 4.24.4
+  build: hf27288f_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.4-hf27288f_0.conda
+  sha256: 3e0f6454190abb27edd2aeb724688ee440de133edb02cbb17d5609ba36aa8be0
+  md5: 1a0287ab734591ad63603734f923016b
+  depends:
   - libabseil * cxx17*
-  - libabseil >=20230125.3,<20230126.0a0
+  - libabseil >=20230802.1,<20230803.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.23.3-hd1fb520_1.conda
-  hash:
-    md5: 78c10e8637a6f8d377f9989327d0267d
-    sha256: 2e2a9b612b8ef8b928f8efac835cd2914722bbab348fa643b99db2efd3b34185
-  build: hd1fb520_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 2495057
-  timestamp: 1693582252190
-- platform: osx-arm64
+  size: 2568098
+  timestamp: 1696556878001
+- kind: conda
   name: libprotobuf
-  version: 4.24.4
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
+  version: 4.25.1
+  build: h810fc01_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.1-h810fc01_2.conda
+  sha256: ed7a9f30f37f637a5a654b7ab7de6317f94680bf7ae534b174360a0fa8720c25
+  md5: e70655adcf48db40f4caa80f81398d11
+  depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=16.0.6
+  - libcxx >=16
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.4-hc9861d8_0.conda
-  hash:
-    md5: ac5438d981e105e053b341eb30c44273
-    sha256: 2e81e023f463ef239e2fb7f56a4e8eed61a1d8e9ca3f2f07bec1668cc369b2ce
-  build: hc9861d8_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2060711
-  timestamp: 1696556460522
-- platform: osx-arm64
+  size: 2160165
+  timestamp: 1708433780566
+- kind: conda
   name: libre2-11
   version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
+  build: h1753957_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.06.02-h1753957_0.conda
+  sha256: 8bafee8f8ef27f4cb0afffe5404dd1abfc5fd6eac1ee9b4847a756d440bd7aa7
+  md5: 3b8652db4bf4e27fa1446526f7a78498
+  depends:
   - __osx >=10.9
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libcxx >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.06.02-h1753957_0.conda
-  hash:
-    md5: 3b8652db4bf4e27fa1446526f7a78498
-    sha256: 8bafee8f8ef27f4cb0afffe5404dd1abfc5fd6eac1ee9b4847a756d440bd7aa7
-  build: h1753957_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
   constrains:
   - re2 2023.06.02.*
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 169587
   timestamp: 1697065827986
-- platform: linux-64
-  name: libsndfile
-  version: 1.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - lame >=3.100,<3.101.0a0
-  - libflac >=1.4.3,<1.5.0a0
-  - libgcc-ng >=12
-  - libogg >=1.3.4,<1.4.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libstdcxx-ng >=12
-  - libvorbis >=1.3.7,<1.4.0a0
-  - mpg123 >=1.32.1,<1.33.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
-  hash:
-    md5: ef1910918dd895516a769ed36b5b3a4e
-    sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
-  build: hc60ed4a_1
-  arch: x86_64
-  subdir: linux-64
+- kind: conda
+  name: libre2-11
+  version: 2023.09.01
+  build: h7a70373_1
   build_number: 1
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 354372
-  timestamp: 1695747735668
-- platform: linux-64
-  name: libsqlite
-  version: 3.44.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.2-h2797004_0.conda
-  hash:
-    md5: 3b6a9f225c3dbe0d24f4fedd4625c5bf
-    sha256: ee2c4d724a3ed60d5b458864d66122fb84c6ce1df62f735f90d8db17b66cd88a
-  build: h2797004_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: Unlicense
-  size: 845830
-  timestamp: 1700863204572
-- platform: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h7a70373_1.conda
+  sha256: 63ebe0a3244b5f1c61337b5b387a2bacd1ca88cd894229a8cd538ef9a4b51d1a
+  md5: e61d774293f3ccfb82561a627e846de4
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - re2 2023.09.01.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232789
+  timestamp: 1708945270812
+- kind: conda
   name: libsqlite
   version: 3.44.2
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.44.2-h091b4b1_0.conda
-  hash:
-    md5: d7e1af696cfadec251a0abdd7b79ed77
-    sha256: f0dc2fe69eddb4bab72ff6bb0da51d689294f466ee1b01e80ced1e7878a21aa5
   build: h091b4b1_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.44.2-h091b4b1_0.conda
+  sha256: f0dc2fe69eddb4bab72ff6bb0da51d689294f466ee1b01e80ced1e7878a21aa5
+  md5: d7e1af696cfadec251a0abdd7b79ed77
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
   license: Unlicense
   size: 815254
   timestamp: 1700863572318
-- platform: linux-64
-  name: libssh2
-  version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
+- kind: conda
+  name: libsqlite
+  version: 3.44.2
+  build: h2797004_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.2-h2797004_0.conda
+  sha256: ee2c4d724a3ed60d5b458864d66122fb84c6ce1df62f735f90d8db17b66cd88a
+  md5: 3b6a9f225c3dbe0d24f4fedd4625c5bf
+  depends:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
-  hash:
-    md5: 1f5a58e686b13bcfde88b93f547d23fe
-    sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
-  build: h0841786_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 271133
-  timestamp: 1685837707056
-- platform: osx-arm64
-  name: libssh2
-  version: 1.11.0
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
-  hash:
-    md5: 029f7dc931a3b626b94823bc77830b01
-    sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
-  build: h7a5bd25_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 255610
-  timestamp: 1685837894256
-- platform: linux-64
+  platform: linux
+  license: Unlicense
+  size: 845830
+  timestamp: 1700863204572
+- kind: conda
   name: libstdcxx-ng
   version: 13.2.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_3.conda
-  hash:
-    md5: 937eaed008f6bf2191c5fe76f87755e9
-    sha256: 6c6c49efedcc5709a66f19fb6b26b69c6a5245310fd1d9a901fd5e38aaf7f882
   build: h7e041cc_3
-  arch: x86_64
-  subdir: linux-64
   build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_3.conda
+  sha256: 6c6c49efedcc5709a66f19fb6b26b69c6a5245310fd1d9a901fd5e38aaf7f882
+  md5: 937eaed008f6bf2191c5fe76f87755e9
+  arch: x86_64
+  platform: linux
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   size: 3842940
   timestamp: 1699753676253
-- platform: linux-64
-  name: libsystemd0
-  version: '253'
-  category: main
-  manager: conda
-  dependencies:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.67,<2.68.0a0
-  - libgcc-ng >=12
-  - libgcrypt >=1.10.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-253-h8c4010b_1.conda
-  hash:
-    md5: 9176b1e2cb8beca37a7510b0e801e38f
-    sha256: 13f5db46b7ded028f5b53fd5373e27a47789b9a655b52a92c4b324099602f29a
-  build: h8c4010b_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: LGPL-2.1-or-later
-  size: 380557
-  timestamp: 1677532757148
-- platform: osx-arm64
+- kind: conda
   name: libtasn1
   version: 4.19.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
-  hash:
-    md5: c35bc17c31579789c76739486fc6d27a
-    sha256: 912e96644ea22b49921c71c9c94bcdd2b6463e9313da895c2fcee298a8c0e44c
   build: h1a8c8d9_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
+  sha256: 912e96644ea22b49921c71c9c94bcdd2b6463e9313da895c2fcee298a8c0e44c
+  md5: c35bc17c31579789c76739486fc6d27a
+  arch: aarch64
+  platform: osx
   license: GPL-3.0-or-later
   license_family: GPL
   size: 116745
   timestamp: 1661325945767
-- platform: linux-64
-  name: libthrift
-  version: 0.18.1
-  category: main
-  manager: conda
-  dependencies:
-  - libevent >=2.1.10,<2.1.11.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.18.1-h5e4af38_0.conda
-  hash:
-    md5: a2fab690ff5efa0d31cf5e27cd433faa
-    sha256: 563ca97f1a5efb48e03fc601ad337a87fc1ddf4eacab9af5f3176a7630d8e31d
-  build: h5e4af38_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3603137
-  timestamp: 1678830042929
-- platform: osx-arm64
-  name: libthrift
-  version: 0.19.0
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  - libevent >=2.1.12,<2.1.13.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.3,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
-  hash:
-    md5: 4b8b21eb00d9019e9fa351141da2a6ac
-    sha256: b2c1b30d36f0412c0c0313db76a0236d736f3a9b887b8ed16182f531e4b7cb80
-  build: h026a170_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 331154
-  timestamp: 1695958512679
-- platform: linux-64
+- kind: conda
   name: libtiff
   version: 4.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - jpeg >=9e,<10a
-  - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.17,<1.18.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libwebp-base >=1.2.4,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-h6adf6a1_2.conda
-  hash:
-    md5: 2e648a34072eb39d7c4fc2a9981c5f0c
-    sha256: e3e18d91fb282b61288d4fd2574dfa31f7ae90ef2737f96722fb6ad3257862ee
-  build: h6adf6a1_2
-  arch: x86_64
-  subdir: linux-64
+  build: h5dffbdd_2
   build_number: 2
-  license: HPND
-  size: 406655
-  timestamp: 1673817946777
-- platform: osx-arm64
-  name: libtiff
-  version: 4.5.0
-  category: main
-  manager: conda
-  dependencies:
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.5.0-h5dffbdd_2.conda
+  sha256: 0207f4234571d393d2f790aedaa1e127dfcd9d7fe3fe886ebdf31c9e7b9f7ce2
+  md5: 8e08eae60de32c940096ee9b4da35685
+  depends:
   - jpeg >=9e,<10a
   - lerc >=4.0.0,<5.0a0
   - libcxx >=14.0.6
@@ -5735,1446 +3591,1014 @@ package:
   - libzlib >=1.2.13,<1.3.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.5.0-h5dffbdd_2.conda
-  hash:
-    md5: 8e08eae60de32c940096ee9b4da35685
-    sha256: 0207f4234571d393d2f790aedaa1e127dfcd9d7fe3fe886ebdf31c9e7b9f7ce2
-  build: h5dffbdd_2
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
+  platform: osx
   license: HPND
   size: 347549
   timestamp: 1673818160649
-- platform: linux-64
-  name: libtool
-  version: 2.4.7
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtool-2.4.7-h27087fc_0.conda
-  hash:
-    md5: f204c8ba400ec475452737094fb81d52
-    sha256: 345b3b580ef91557a82425ea3f432a70a8748c040deb14570b9f4dca4af3e3d1
-  build: h27087fc_0
-  arch: x86_64
+- kind: conda
+  name: libtiff
+  version: 4.5.0
+  build: h6adf6a1_2
+  build_number: 2
   subdir: linux-64
-  build_number: 0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 411817
-  timestamp: 1672361825713
-- platform: linux-64
-  name: libudev1
-  version: '253'
-  category: main
-  manager: conda
-  dependencies:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.67,<2.68.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-h6adf6a1_2.conda
+  sha256: e3e18d91fb282b61288d4fd2574dfa31f7ae90ef2737f96722fb6ad3257862ee
+  md5: 2e648a34072eb39d7c4fc2a9981c5f0c
+  depends:
+  - jpeg >=9e,<10a
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.17,<1.18.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libudev1-253-h0b41bf4_1.conda
-  hash:
-    md5: bb38b19a41bb94e8a19dbfb062d499c7
-    sha256: 1419fc6dc85f9aad95df733af4e442feb27da90ed74b9b67dbdc090151bdec24
-  build: h0b41bf4_1
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: LGPL-2.1-or-later
-  size: 118700
-  timestamp: 1677532765365
-- platform: osx-arm64
+  platform: linux
+  license: HPND
+  size: 406655
+  timestamp: 1673817946777
+- kind: conda
   name: libunistring
   version: 0.9.10
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
-  hash:
-    md5: d88e77a4861e20bd96bde6628ee7a5ae
-    sha256: a1afe12ab199f82f339eae83405d293d197f2485d45346a709703bc7e8299949
   build: h3422bc3_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
+  sha256: a1afe12ab199f82f339eae83405d293d197f2485d45346a709703bc7e8299949
+  md5: d88e77a4861e20bd96bde6628ee7a5ae
+  arch: aarch64
+  platform: osx
   license: GPL-3.0-only OR LGPL-3.0-only
   size: 1577561
   timestamp: 1626955172521
-- platform: linux-64
-  name: libutf8proc
-  version: 2.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
-  hash:
-    md5: ede4266dc02e875fe1ea77b25dd43747
-    sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
-  build: h166bdaf_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 101070
-  timestamp: 1667316029302
-- platform: osx-arm64
-  name: libutf8proc
-  version: 2.8.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
-  hash:
-    md5: f8c9c41a122ab3abdf8943b13f4957ee
-    sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
-  build: h1a8c8d9_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 103492
-  timestamp: 1667316405233
-- platform: linux-64
+- kind: conda
   name: libuuid
   version: 2.38.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-  hash:
-    md5: 40b61aab5c7ba9ff276c41cfffe6b80b
-    sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
   build: h0b41bf4_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+  sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
+  md5: 40b61aab5c7ba9ff276c41cfffe6b80b
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 33601
   timestamp: 1680112270483
-- platform: linux-64
-  name: libvorbis
-  version: 1.3.7
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  - libogg >=1.3.4,<1.4.0a0
-  - libstdcxx-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
-  hash:
-    md5: 309dec04b70a3cc0f1e84a4013683bc0
-    sha256: 53080d72388a57b3c31ad5805c93a7328e46ff22fab7c44ad2a86d712740af33
-  build: h9c3ff4c_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 286280
-  timestamp: 1610609811627
-- platform: osx-arm64
+- kind: conda
   name: libvpx
   version: 1.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.13.1-hb765f3a_0.conda
-  hash:
-    md5: d62a0d3d8c01bd9fad3fd17d720d0cf5
-    sha256: 3a9c5e903cc212f426bb4515293b45c84cb6173fd9ecc5bdba144e07c817d84c
   build: hb765f3a_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.13.1-hb765f3a_0.conda
+  sha256: 3a9c5e903cc212f426bb4515293b45c84cb6173fd9ecc5bdba144e07c817d84c
+  md5: d62a0d3d8c01bd9fad3fd17d720d0cf5
+  depends:
+  - libcxx >=15.0.7
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 1134986
   timestamp: 1696342737036
-- platform: linux-64
+- kind: conda
   name: libwebp-base
   version: 1.3.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
-  hash:
-    md5: 30de3fd9b3b602f7473f30e684eeea8c
-    sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - libwebp 1.3.2
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 401830
-  timestamp: 1694709121323
-- platform: osx-arm64
-  name: libwebp-base
-  version: 1.3.2
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
-  hash:
-    md5: 85dbc11098cdbe4244cd73f29a3ab795
-    sha256: a159b848193043fb58465ae6a449361615dadcf27babfe0b18db2bd3eb59e958
   build: hb547adb_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+  sha256: a159b848193043fb58465ae6a449361615dadcf27babfe0b18db2bd3eb59e958
+  md5: 85dbc11098cdbe4244cd73f29a3ab795
   constrains:
   - libwebp 1.3.2
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 273844
   timestamp: 1694709510635
-- platform: linux-64
+- kind: conda
+  name: libwebp-base
+  version: 1.3.2
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+  sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
+  md5: 30de3fd9b3b602f7473f30e684eeea8c
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - libwebp 1.3.2
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 401830
+  timestamp: 1694709121323
+- kind: conda
   name: libxcb
   version: '1.13'
-  category: main
-  manager: conda
-  dependencies:
+  build: h7f98852_1004
+  build_number: 1004
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
+  sha256: 8d5d24cbeda9282dd707edd3156e5fde2e3f3fe86c802fa7ce08c8f1e803bfd9
+  md5: b3653fdc58d03face9724f602218a904
+  depends:
   - libgcc-ng >=9.4.0
   - pthread-stubs
   - xorg-libxau
   - xorg-libxdmcp
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.13-h7f98852_1004.tar.bz2
-  hash:
-    md5: b3653fdc58d03face9724f602218a904
-    sha256: 8d5d24cbeda9282dd707edd3156e5fde2e3f3fe86c802fa7ce08c8f1e803bfd9
-  build: h7f98852_1004
   arch: x86_64
-  subdir: linux-64
-  build_number: 1004
+  platform: linux
   license: MIT
   license_family: MIT
   size: 399895
   timestamp: 1636658924671
-- platform: osx-arm64
+- kind: conda
   name: libxcb
   version: '1.13'
-  category: main
-  manager: conda
-  dependencies:
+  build: h9b22ae9_1004
+  build_number: 1004
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.13-h9b22ae9_1004.tar.bz2
+  sha256: a89b1e46650c01a8791c201c108d6d49a0a5604dd24ddb18902057bbd90f7dbb
+  md5: 6b3457a192f8091cb413962f65740ac4
+  depends:
   - pthread-stubs
   - xorg-libxau
   - xorg-libxdmcp
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.13-h9b22ae9_1004.tar.bz2
-  hash:
-    md5: 6b3457a192f8091cb413962f65740ac4
-    sha256: a89b1e46650c01a8791c201c108d6d49a0a5604dd24ddb18902057bbd90f7dbb
-  build: h9b22ae9_1004
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 1004
+  platform: osx
   license: MIT
   license_family: MIT
   size: 353124
   timestamp: 1636659450212
-- platform: linux-64
-  name: libxkbcommon
-  version: 1.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxcb >=1.13,<1.14.0a0
-  - libxml2 >=2.10.3,<2.11.0a0
-  - xkeyboard-config
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.5.0-h79f4944_1.conda
-  hash:
-    md5: 04a39cdd663f295653fc143851830563
-    sha256: f57aa3eeeb4abbeeafb6e61fbffa6f89fa2434e914c1eb65551e6e0905b363aa
-  build: h79f4944_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: MIT/X11 Derivative
-  license_family: MIT
-  size: 563179
-  timestamp: 1678659270113
-- platform: linux-64
+- kind: conda
   name: libxml2
   version: 2.10.3
-  category: main
-  manager: conda
-  dependencies:
+  build: hca2bb57_4
+  build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.10.3-hca2bb57_4.conda
+  sha256: d4170f1fe356768758b13a51db123f990bff81b0eae0d5a0ba11c7ca6b9536f4
+  md5: bb808b654bdc3c783deaf107a2ffb503
+  depends:
   - icu >=70.1,<71.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.10.3-hca2bb57_4.conda
-  hash:
-    md5: bb808b654bdc3c783deaf107a2ffb503
-    sha256: d4170f1fe356768758b13a51db123f990bff81b0eae0d5a0ba11c7ca6b9536f4
-  build: hca2bb57_4
   arch: x86_64
-  subdir: linux-64
-  build_number: 4
+  platform: linux
   license: MIT
   license_family: MIT
   size: 713891
   timestamp: 1679341466192
-- platform: osx-arm64
+- kind: conda
   name: libxml2
   version: 2.11.6
-  category: main
-  manager: conda
-  dependencies:
+  build: h0d0cfa8_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.6-h0d0cfa8_0.conda
+  sha256: 07d2da8f3fb00fb6f84cd36b5329174b878105889f0fe21e79981f27573b47af
+  md5: 37e112ce9494adfcee6c0c7bf3b5d98d
+  depends:
   - icu >=73.2,<74.0a0
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.6-h0d0cfa8_0.conda
-  hash:
-    md5: 37e112ce9494adfcee6c0c7bf3b5d98d
-    sha256: 07d2da8f3fb00fb6f84cd36b5329174b878105889f0fe21e79981f27573b47af
-  build: h0d0cfa8_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
   size: 588705
   timestamp: 1700245318212
-- platform: linux-64
+- kind: conda
   name: libzlib
   version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
-  hash:
-    md5: f36c115f1ee199da648e0597ec2047ad
-    sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
-  build: hd590300_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  constrains:
-  - zlib 1.2.13 *_5
-  license: Zlib
-  license_family: Other
-  size: 61588
-  timestamp: 1686575217516
-- platform: osx-arm64
-  name: libzlib
-  version: 1.2.13
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
-  hash:
-    md5: 1a47f5236db2e06a320ffa0392f81bd8
-    sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
   build: h53f4e23_5
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+  sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
+  md5: 1a47f5236db2e06a320ffa0392f81bd8
   constrains:
   - zlib 1.2.13 *_5
+  arch: aarch64
+  platform: osx
   license: Zlib
   license_family: Other
   size: 48102
   timestamp: 1686575426584
-- platform: linux-64
-  name: lightning-utilities
-  version: 0.10.0
-  category: main
-  manager: conda
-  dependencies:
-  - packaging >=17.1
-  - python >=3.8
-  - typing_extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.10.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d05f62f48f777fa3ea1a0e555ca67895
-    sha256: 72d1b0103bd3158d991939f2fe27406ab2499b7b81d95d27ea9df69ba240b4fa
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: hd590300_5
+  build_number: 5
   subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 26088
-  timestamp: 1700426691008
-- platform: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+  sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
+  md5: f36c115f1ee199da648e0597ec2047ad
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - zlib 1.2.13 *_5
+  arch: x86_64
+  platform: linux
+  license: Zlib
+  license_family: Other
+  size: 61588
+  timestamp: 1686575217516
+- kind: conda
   name: lightning-utilities
   version: 0.10.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.10.0-pyhd8ed1ab_0.conda
+  sha256: 72d1b0103bd3158d991939f2fe27406ab2499b7b81d95d27ea9df69ba240b4fa
+  md5: d05f62f48f777fa3ea1a0e555ca67895
+  depends:
   - packaging >=17.1
   - python >=3.8
   - typing_extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.10.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: d05f62f48f777fa3ea1a0e555ca67895
-    sha256: 72d1b0103bd3158d991939f2fe27406ab2499b7b81d95d27ea9df69ba240b4fa
-  build: pyhd8ed1ab_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
+  purls:
+  - pkg:pypi/lightning-utilities
   size: 26088
   timestamp: 1700426691008
-- platform: linux-64
+- kind: conda
   name: llvm-openmp
   version: 17.0.6
-  category: main
-  manager: conda
-  dependencies:
+  build: h4dfa4b3_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-17.0.6-h4dfa4b3_0.conda
+  sha256: 18a9db4cc139e72e8eac80a34f6536491fe318d3785bc2c35fac42cd00676376
+  md5: c1665f9c1c9f6c93d8b4e492a6a39056
+  depends:
   - libzlib >=1.2.13,<1.3.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-17.0.6-h4dfa4b3_0.conda
-  hash:
-    md5: c1665f9c1c9f6c93d8b4e492a6a39056
-    sha256: 18a9db4cc139e72e8eac80a34f6536491fe318d3785bc2c35fac42cd00676376
-  build: h4dfa4b3_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - openmp 17.0.6|17.0.6.*
+  arch: x86_64
+  platform: linux
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   size: 41265157
   timestamp: 1701222660202
-- platform: osx-arm64
+- kind: conda
   name: llvm-openmp
   version: 17.0.6
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.6-hcd81f8e_0.conda
-  hash:
-    md5: 52019d2fa0eddbbc4e6dcd30fae0c0a4
-    sha256: 0c217326c5931c1416b82f98169b8a8a52139f6f5f299dbb2efa7b21f65f225a
   build: hcd81f8e_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.6-hcd81f8e_0.conda
+  sha256: 0c217326c5931c1416b82f98169b8a8a52139f6f5f299dbb2efa7b21f65f225a
+  md5: 52019d2fa0eddbbc4e6dcd30fae0c0a4
   constrains:
   - openmp 17.0.6|17.0.6.*
+  arch: aarch64
+  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   size: 274631
   timestamp: 1701222947083
-- platform: linux-64
-  name: lz4-c
-  version: 1.9.4
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
-  hash:
-    md5: 318b08df404f9c9be5712aaa5a6f0bb0
-    sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
-  build: hcb278e6_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 143402
-  timestamp: 1674727076728
-- platform: osx-arm64
-  name: lz4-c
-  version: 1.9.4
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=14.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
-  hash:
-    md5: 45505bec548634f7d05e02fb25262cb9
-    sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
-  build: hb7217d7_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 141188
-  timestamp: 1674727268278
-- platform: linux-64
+- kind: conda
   name: markdown
   version: 3.5.1
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata >=4.4
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 323495027ffa625701129acebf861412
-    sha256: 35e8990504cf8dc7e2bb63efd855fb0a0d5c0d77bf79403235e757c24a83ec1d
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 76573
-  timestamp: 1698797645633
-- platform: osx-arm64
-  name: markdown
-  version: 3.5.1
-  category: main
-  manager: conda
-  dependencies:
-  - importlib-metadata >=4.4
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 323495027ffa625701129acebf861412
-    sha256: 35e8990504cf8dc7e2bb63efd855fb0a0d5c0d77bf79403235e757c24a83ec1d
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-3.5.1-pyhd8ed1ab_0.conda
+  sha256: 35e8990504cf8dc7e2bb63efd855fb0a0d5c0d77bf79403235e757c24a83ec1d
+  md5: 323495027ffa625701129acebf861412
+  depends:
+  - importlib-metadata >=4.4
+  - python >=3.6
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/markdown
   size: 76573
   timestamp: 1698797645633
-- platform: linux-64
+- kind: conda
   name: markupsafe
-  version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_1.conda
-  hash:
-    md5: b74e07a054c479e45a83a83fc5be713c
-    sha256: ac46cc2f6d4bbeedcd2f508e43f43143a9286ced55730d8d97a3c91ceceb0d56
-  build: py310h2372a71_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  version: 2.1.5
+  build: py39h17cfd9d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.5-py39h17cfd9d_0.conda
+  sha256: e18591162cb401bc651a69bd2545a679b69c54405d778d05778f43ba76c6a4dd
+  md5: 554a0bcb046e1bac7887a92f33b96acc
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
   constrains:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 24054
-  timestamp: 1695367637074
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/markupsafe
+  size: 23827
+  timestamp: 1706900341193
+- kind: conda
   name: markupsafe
-  version: 2.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py310h2aa6e3c_1.conda
-  hash:
-    md5: bcec7846de67985acb2152aa1fc0b45f
-    sha256: 4ea6a82aae3c846e8d2d4bf194124d552fb648b8ba07388be71bc52441fc69f1
-  build: py310h2aa6e3c_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
+  version: 2.1.5
+  build: py39hd1e30aa_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py39hd1e30aa_0.conda
+  sha256: 855d305ceda4751cdd495923104dd34da5a6be45e4fd50a4e80361d9f95bcb38
+  md5: 9a9a22eb1f83c44953319ee3b027769f
+  depends:
+  - libgcc-ng >=12
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   constrains:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 23850
-  timestamp: 1695368071532
-- platform: linux-64
+  purls:
+  - pkg:pypi/markupsafe
+  size: 24314
+  timestamp: 1706900151453
+- kind: pypi
   name: matplotlib
-  version: 3.8.2
-  category: main
-  manager: conda
-  dependencies:
-  - matplotlib-base >=3.8.2,<3.8.3.0a0
-  - pyqt >=5.10
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tornado >=5
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.8.2-py310hff52083_0.conda
-  hash:
-    md5: 7baa698e8867dbc42c18a3f9cab69f99
-    sha256: 55c3d79e99284d530e5a2dbd7e0b9879b9a943c16bbbfe32567733fc47520e8a
-  build: py310hff52083_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
-  size: 8381
-  timestamp: 1700509781531
-- platform: osx-arm64
+  version: 3.8.4
+  url: https://files.pythonhosted.org/packages/d5/88/83aee628339486de57fcc8c1387e28de816182edcfc42928cff02c364664/matplotlib-3.8.4-cp39-cp39-macosx_11_0_arm64.whl
+  sha256: 1c13f041a7178f9780fb61cc3a2b10423d5e125480e4be51beaf62b172413b67
+  requires_dist:
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.22.0
+  - kiwisolver>=1.3.1
+  - numpy>=1.21
+  - packaging>=20.0
+  - pillow>=8
+  - pyparsing>=2.3.1
+  - python-dateutil>=2.7
+  - importlib-resources>=3.2.0 ; python_version < '3.10'
+  requires_python: '>=3.9'
+- kind: pypi
   name: matplotlib
-  version: 3.8.2
-  category: main
-  manager: conda
-  dependencies:
-  - matplotlib-base >=3.8.2,<3.8.3.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tornado >=5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.8.2-py310hb6292c7_0.conda
-  hash:
-    md5: 1938c6e329a8d1c2702c051369b38ee0
-    sha256: b0fdcace860c8968b971b53cd54ced240459b5f865a1a3ba62fb924d672c0d86
-  build: py310hb6292c7_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
-  size: 8570
-  timestamp: 1700510156739
-- platform: linux-64
-  name: matplotlib-base
-  version: 3.8.2
-  category: main
-  manager: conda
-  dependencies:
-  - certifi >=2020.06.20
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - freetype >=2.12.1,<3.0a0
-  - kiwisolver >=1.3.1
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - numpy >=1.21,<2
-  - numpy >=1.22.4,<2.0a0
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1
-  - python >=3.10,<3.11.0a0
-  - python-dateutil >=2.7
-  - python_abi 3.10.* *_cp310
-  - tk >=8.6.13,<8.7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.2-py310h62c0568_0.conda
-  hash:
-    md5: 3cbbc7d0b54df02c9a006d3de14911d9
-    sha256: 078f5f1ece533a03710dd6d644555f1f2f4cbe18f1412d695ffb304e3d8c9381
-  build: py310h62c0568_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
-  size: 6938926
-  timestamp: 1700509738716
-- platform: osx-arm64
-  name: matplotlib-base
-  version: 3.8.2
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - certifi >=2020.06.20
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - freetype >=2.12.1,<3.0a0
-  - kiwisolver >=1.3.1
-  - libcxx >=16.0.6
-  - numpy >=1.21,<2
-  - numpy >=1.22.4,<2.0a0
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python-dateutil >=2.7
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.2-py310h9d2df84_0.conda
-  hash:
-    md5: 5603116a4796c68b0da10ada7864da2e
-    sha256: d51935c40776b55fea4f7287e8c4e7986a82610f699fa3ce921a9b8d17669e24
-  build: py310h9d2df84_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
-  size: 6817411
-  timestamp: 1700510094892
-- platform: linux-64
+  version: 3.8.4
+  url: https://files.pythonhosted.org/packages/5e/2c/513395a63a9e1124a5648addbf73be23cc603f955af026b04416da98dc96/matplotlib-3.8.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 606e3b90897554c989b1e38a258c626d46c873523de432b1462f295db13de6f9
+  requires_dist:
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.22.0
+  - kiwisolver>=1.3.1
+  - numpy>=1.21
+  - packaging>=20.0
+  - pillow>=8
+  - pyparsing>=2.3.1
+  - python-dateutil>=2.7
+  - importlib-resources>=3.2.0 ; python_version < '3.10'
+  requires_python: '>=3.9'
+- kind: pypi
+  name: matplotlib-inline
+  version: 0.1.7
+  url: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
+  sha256: df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca
+  requires_dist:
+  - traitlets
+  requires_python: '>=3.8'
+- kind: conda
   name: mkl
   version: 2023.2.0
-  category: main
-  manager: conda
-  dependencies:
+  build: h84fe81f_50496
+  build_number: 50496
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2023.2.0-h84fe81f_50496.conda
+  sha256: 046073737bf73153b0c39e343b197cdf0b7867d336962369407465a17ea5979a
+  md5: 81d4a1a57d618adf0152db973d93b2ad
+  depends:
   - _openmp_mutex * *_llvm
   - _openmp_mutex >=4.5
   - llvm-openmp >=17.0.3
   - tbb 2021.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2023.2.0-h84fe81f_50496.conda
-  hash:
-    md5: 81d4a1a57d618adf0152db973d93b2ad
-    sha256: 046073737bf73153b0c39e343b197cdf0b7867d336962369407465a17ea5979a
-  build: h84fe81f_50496
   arch: x86_64
-  subdir: linux-64
-  build_number: 50496
+  platform: linux
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
   size: 164432797
   timestamp: 1698350676814
-- platform: linux-64
+- kind: conda
   name: mkl-devel
   version: 2023.2.0
-  category: main
-  manager: conda
-  dependencies:
+  build: ha770c72_50496
+  build_number: 50496
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2023.2.0-ha770c72_50496.conda
+  sha256: ddd54fd21d6ac8eec97674db20a8752a7eadd60c9778eb1443e075196813037a
+  md5: 3b4c50e31ff098b18a450e4f5f860adf
+  depends:
   - mkl 2023.2.0 h84fe81f_50496
   - mkl-include 2023.2.0 h84fe81f_50496
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2023.2.0-ha770c72_50496.conda
-  hash:
-    md5: 3b4c50e31ff098b18a450e4f5f860adf
-    sha256: ddd54fd21d6ac8eec97674db20a8752a7eadd60c9778eb1443e075196813037a
-  build: ha770c72_50496
   arch: x86_64
-  subdir: linux-64
-  build_number: 50496
+  platform: linux
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
   size: 29681
   timestamp: 1698351536220
-- platform: linux-64
+- kind: conda
   name: mkl-include
   version: 2023.2.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2023.2.0-h84fe81f_50496.conda
-  hash:
-    md5: 7af9fd0b2d7219f4a4200a34561340f6
-    sha256: da1720a3e065273e2456481b28abd64abc2396d221d87a02db5f14053be61a68
   build: h84fe81f_50496
-  arch: x86_64
-  subdir: linux-64
   build_number: 50496
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2023.2.0-h84fe81f_50496.conda
+  sha256: da1720a3e065273e2456481b28abd64abc2396d221d87a02db5f14053be61a68
+  md5: 7af9fd0b2d7219f4a4200a34561340f6
+  arch: x86_64
+  platform: linux
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
   size: 704619
   timestamp: 1698351108112
-- platform: linux-64
-  name: mpg123
-  version: 1.32.3
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.3-h59595ed_0.conda
-  hash:
-    md5: bdadff838d5437aea83607ced8b37f75
-    sha256: f02b8ed16b3a488938b5f9453d19ea315ce6ed0d46cc389ecfaa28f2a4c3cb16
-  build: h59595ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LGPL-2.1-only
-  license_family: LGPL
-  size: 491969
-  timestamp: 1696265613952
-- platform: linux-64
+- kind: pypi
+  name: moviepy
+  version: 1.0.3
+  url: https://files.pythonhosted.org/packages/18/54/01a8c4e35c75ca9724d19a7e4de9dc23f0ceb8769102c7de056113af61c3/moviepy-1.0.3.tar.gz
+  sha256: 2884e35d1788077db3ff89e763c5ba7bfddbd7ae9108c9bc809e7ba58fa433f5
+  requires_dist:
+  - decorator<5.0,>=4.0.2
+  - tqdm<5.0,>=4.11.2
+  - requests<3.0,>=2.8.1
+  - proglog<=1.0.0
+  - numpy>=1.17.3 ; python_version != '2.7'
+  - imageio<2.5,>=2.0 ; python_version < '3.4'
+  - numpy ; python_version >= '2.7'
+  - imageio<3.0,>=2.5 ; python_version >= '3.4'
+  - imageio-ffmpeg>=0.2.0 ; python_version >= '3.4'
+  - numpydoc<1.0,>=0.6.0 ; extra == 'doc'
+  - sphinx-rtd-theme<1.0,>=0.1.10b0 ; extra == 'doc'
+  - sphinx<2.0,>=1.5.2 ; extra == 'doc'
+  - pygame<2.0,>=1.9.3 ; python_version < '3.8' and extra == 'doc'
+  - youtube-dl ; extra == 'optional'
+  - opencv-python<4.0,>=3.0 ; python_version != '2.7' and extra == 'optional'
+  - scipy<1.5,>=0.19.0 ; python_version != '3.3' and extra == 'optional'
+  - scikit-image<1.0,>=0.13.0 ; python_version >= '3.4' and extra == 'optional'
+  - scikit-learn ; python_version >= '3.4' and extra == 'optional'
+  - matplotlib<3.0,>=2.0.0 ; python_version >= '3.4' and extra == 'optional'
+  - coverage<5.0 ; extra == 'test'
+  - coveralls<2.0,>=1.1 ; extra == 'test'
+  - pytest-cov<3.0,>=2.5.1 ; extra == 'test'
+  - pytest<4.0,>=3.0.0 ; extra == 'test'
+  - requests<3.0,>=2.8.1 ; extra == 'test'
+- kind: conda
   name: multidict
-  version: 6.0.4
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.4-py310h2372a71_1.conda
-  hash:
-    md5: 7ca797f0a0c390ede770f415f5d5e039
-    sha256: d8180dcee801bcde6408d924bab0010fc956ae7a14681694af21f9d4382d8ee8
-  build: py310h2372a71_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  version: 6.0.5
+  build: py39h02fc5c5_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.0.5-py39h02fc5c5_0.conda
+  sha256: ccf5b7bd1f858a8bf7dfea38e2a69ba4ca89c7c95bced47a98e5bf186b59b3ae
+  md5: 634fe6827968117d1fe51b025849fd99
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
   license: Apache-2.0
   license_family: APACHE
-  size: 56905
-  timestamp: 1696716235723
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/multidict
+  size: 50951
+  timestamp: 1707041090557
+- kind: conda
   name: multidict
-  version: 6.0.4
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.0.4-py310h8e9501a_1.conda
-  hash:
-    md5: ca712ab597b2a0e11e0686882f0d0f04
-    sha256: c06cdef2cedc026a44ae084f95ae3f2086780946c047347beffcfba32c6765c7
-  build: py310h8e9501a_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
+  version: 6.0.5
+  build: py39hd1e30aa_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.0.5-py39hd1e30aa_0.conda
+  sha256: 9d07c952bd052b95155942d07d30d95eb0d8dfecfc9b0b40b8ba50323dc719da
+  md5: e2005168d5a334f88a1d95d02e139239
+  depends:
+  - libgcc-ng >=12
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   license: Apache-2.0
   license_family: APACHE
-  size: 51099
-  timestamp: 1696716466777
-- platform: linux-64
-  name: munkres
-  version: 1.1.4
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 2ba8498c1018c1e9c61eb99b973dfe19
-    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-  build: pyh9f0ad1d_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 12452
-  timestamp: 1600387789153
-- platform: osx-arm64
-  name: munkres
-  version: 1.1.4
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 2ba8498c1018c1e9c61eb99b973dfe19
-    sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-  build: pyh9f0ad1d_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 12452
-  timestamp: 1600387789153
-- platform: linux-64
-  name: mysql-common
-  version: 8.0.33
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_6.conda
-  hash:
-    md5: 80bf3b277c120dd294b51d404b931a75
-    sha256: c8b2c5c9d0d013a4f6ef96cb4b339bfdc53a74232d8c61ed08178e5b1ec4eb63
-  build: hf1915f5_6
-  arch: x86_64
-  subdir: linux-64
-  build_number: 6
-  size: 753467
-  timestamp: 1698937026421
-- platform: linux-64
-  name: mysql-libs
-  version: 8.0.33
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-common 8.0.33 hf1915f5_6
-  - openssl >=3.1.4,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_6.conda
-  hash:
-    md5: e87530d1b12dd7f4e0f856dc07358d60
-    sha256: 78c905637dac79b197395065c169d452b8ca2a39773b58e45e23114f1cb6dcdb
-  build: hca2cd23_6
-  arch: x86_64
-  subdir: linux-64
-  build_number: 6
-  size: 1530126
-  timestamp: 1698937116126
-- platform: linux-64
+  purls:
+  - pkg:pypi/multidict
+  size: 57171
+  timestamp: 1707040916459
+- kind: pypi
+  name: nbformat
+  version: 5.10.4
+  url: https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl
+  sha256: 3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b
+  requires_dist:
+  - fastjsonschema>=2.15
+  - jsonschema>=2.6
+  - jupyter-core!=5.0.*,>=4.12
+  - traitlets>=5.1
+  - myst-parser ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - sphinxcontrib-github-alt ; extra == 'docs'
+  - sphinxcontrib-spelling ; extra == 'docs'
+  - pep440 ; extra == 'test'
+  - pre-commit ; extra == 'test'
+  - pytest ; extra == 'test'
+  - testpath ; extra == 'test'
+  requires_python: '>=3.8'
+- kind: conda
   name: ncurses
   version: '6.4'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
-  hash:
-    md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
-    sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
-  build: h59595ed_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: X11 AND BSD-3-Clause
-  size: 884434
-  timestamp: 1698751260967
-- platform: osx-arm64
-  name: ncurses
-  version: '6.4'
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
-  hash:
-    md5: 52b6f254a7b9663e854f44b6570ed982
-    sha256: f6890634f815e8408d08f36503353f8dfd7b055e4c3b9ea2ee52180255cf4b0a
   build: h463b476_2
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+  sha256: f6890634f815e8408d08f36503353f8dfd7b055e4c3b9ea2ee52180255cf4b0a
+  md5: 52b6f254a7b9663e854f44b6570ed982
+  depends:
+  - __osx >=10.9
+  arch: aarch64
+  platform: osx
   license: X11 AND BSD-3-Clause
   size: 794741
   timestamp: 1698751574074
-- platform: linux-64
+- kind: conda
+  name: ncurses
+  version: '6.4'
+  build: h59595ed_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+  sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
+  md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
+  license: X11 AND BSD-3-Clause
+  size: 884434
+  timestamp: 1698751260967
+- kind: pypi
+  name: nest-asyncio
+  version: 1.6.0
+  url: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
+  sha256: 87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c
+  requires_python: '>=3.5'
+- kind: conda
   name: nettle
   version: '3.6'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.6-he412f7d_0.tar.bz2
-  hash:
-    md5: f050099af540c1c960c813b06bca89ad
-    sha256: d929f0c53f2bb74c8e3d97dc1c53cc76b7cec97837fcf87998fa3dd447f03b36
   build: he412f7d_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.6-he412f7d_0.tar.bz2
+  sha256: d929f0c53f2bb74c8e3d97dc1c53cc76b7cec97837fcf87998fa3dd447f03b36
+  md5: f050099af540c1c960c813b06bca89ad
+  depends:
+  - libgcc-ng >=7.5.0
+  arch: x86_64
+  platform: linux
   license: GPL 2 and LGPL3
   license_family: GPL
   size: 6773272
   timestamp: 1605211080998
-- platform: osx-arm64
+- kind: conda
   name: nettle
   version: 3.9.1
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
-  hash:
-    md5: b157977e1ec1dde3ba7ebc6e0dde363f
-    sha256: 5de149b6e35adac11e22ae02516a7466412348690da52049f80ea07fe544896d
   build: h40ed0f5_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
+  sha256: 5de149b6e35adac11e22ae02516a7466412348690da52049f80ea07fe544896d
+  md5: b157977e1ec1dde3ba7ebc6e0dde363f
+  arch: aarch64
+  platform: osx
   license: GPL 2 and LGPL3
   license_family: GPL
   size: 510164
   timestamp: 1686310071126
-- platform: linux-64
+- kind: pypi
   name: networkx
   version: 3.2.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.9
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 425fce3b531bed6ec3c74fab3e5f0a1c
-    sha256: 7629aa4f9f8cdff45ea7a4701fe58dccce5bf2faa01c26eb44cbb27b7e15ca9d
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - matplotlib >=3.5
-  - scipy >=1.9,!=1.11.0,!=1.11.1
-  - numpy >=1.22
-  - pandas >=1.4
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 1149552
-  timestamp: 1698504905258
-- platform: osx-arm64
-  name: networkx
-  version: 3.2.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.9
-  url: https://conda.anaconda.org/conda-forge/noarch/networkx-3.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 425fce3b531bed6ec3c74fab3e5f0a1c
-    sha256: 7629aa4f9f8cdff45ea7a4701fe58dccce5bf2faa01c26eb44cbb27b7e15ca9d
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  constrains:
-  - matplotlib >=3.5
-  - scipy >=1.9,!=1.11.0,!=1.11.1
-  - numpy >=1.22
-  - pandas >=1.4
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 1149552
-  timestamp: 1698504905258
-- platform: linux-64
-  name: nspr
-  version: '4.35'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
-  hash:
-    md5: da0ec11a6454ae19bff5b02ed881a2b1
-    sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
-  build: h27087fc_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 226848
-  timestamp: 1669784948267
-- platform: linux-64
-  name: nss
-  version: '3.95'
-  category: main
-  manager: conda
-  dependencies:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libsqlite >=3.44.2,<4.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - nspr >=4.35,<5.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.95-h1d7d5a4_0.conda
-  hash:
-    md5: d3a8067adcc45a923f4b1987c91d69da
-    sha256: 02d8e38b4708ce707e51084d0dff7286e6e6d24d1bf32ebbda7710fac4a0581e
-  build: h1d7d5a4_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 2001045
-  timestamp: 1701082895718
-- platform: linux-64
+  url: https://files.pythonhosted.org/packages/d5/f0/8fbc882ca80cf077f1b246c0e3c3465f7f415439bdea6b899f6b19f61f70/networkx-3.2.1-py3-none-any.whl
+  sha256: f18c69adc97877c42332c170849c96cefa91881c99a7cb3e95b7c659ebdc1ec2
+  requires_dist:
+  - numpy>=1.22 ; extra == 'default'
+  - scipy!=1.11.0,!=1.11.1,>=1.9 ; extra == 'default'
+  - matplotlib>=3.5 ; extra == 'default'
+  - pandas>=1.4 ; extra == 'default'
+  - changelist==0.4 ; extra == 'developer'
+  - pre-commit>=3.2 ; extra == 'developer'
+  - mypy>=1.1 ; extra == 'developer'
+  - rtoml ; extra == 'developer'
+  - sphinx>=7 ; extra == 'doc'
+  - pydata-sphinx-theme>=0.14 ; extra == 'doc'
+  - sphinx-gallery>=0.14 ; extra == 'doc'
+  - numpydoc>=1.6 ; extra == 'doc'
+  - pillow>=9.4 ; extra == 'doc'
+  - nb2plots>=0.7 ; extra == 'doc'
+  - texext>=0.6.7 ; extra == 'doc'
+  - nbconvert<7.9 ; extra == 'doc'
+  - lxml>=4.6 ; extra == 'extra'
+  - pygraphviz>=1.11 ; extra == 'extra'
+  - pydot>=1.4.2 ; extra == 'extra'
+  - sympy>=1.10 ; extra == 'extra'
+  - pytest>=7.2 ; extra == 'test'
+  - pytest-cov>=4.0 ; extra == 'test'
+  requires_python: '>=3.9'
+- kind: conda
   name: numpy
-  version: 1.26.2
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.26.4
+  build: py39h474f0d3_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py39h474f0d3_0.conda
+  sha256: fa792c330e1d18854e4ca1ea8bf90ffae6787c133ebdc331f1ba6f565d28b599
+  md5: aa265f5697237aa13cc10f53fa8acc4f
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
   - liblapack >=3.9.0,<4.0a0
   - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.2-py310hb13e2d6_0.conda
-  hash:
-    md5: d3147cfbf72d6ae7bba10562208f6def
-    sha256: f5ea7769beb7827f4f5858d28bbdbc814c01649cb8cb81cccbba476ebe3798cd
-  build: py310hb13e2d6_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6922736
-  timestamp: 1700875005993
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/numpy
+  size: 7039431
+  timestamp: 1707225726227
+- kind: conda
   name: numpy
-  version: 1.26.2
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
+  version: 1.26.4
+  build: py39h7aa2656_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py39h7aa2656_0.conda
+  sha256: e7adae3f0ffdc319ce32ea10484d9cc36db4317ce5b525cfdcb97651786a928a
+  md5: c027ed77947314469686cff520a71e5f
+  depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libcxx >=16.0.6
+  - libcxx >=16
   - liblapack >=3.9.0,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.2-py310h30ee222_0.conda
-  hash:
-    md5: baea68ccbc288b1a8afb237ddee162c8
-    sha256: d1c03544798b3916c97571dcc3ec3cde8ad2d9afe2f7ab82277fdadef4186e46
-  build: py310h30ee222_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 5562504
-  timestamp: 1700875196095
-- platform: linux-64
+  purls:
+  - pkg:pypi/numpy
+  size: 5492058
+  timestamp: 1707226364958
+- kind: conda
   name: oauthlib
   version: 3.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - blinker
-  - cryptography
-  - pyjwt >=1.0.0
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.2.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 8f882b197fd9c4941a787926baea4868
-    sha256: 0cfd5146a91d3974f4abfc2a45de890371d510a77238fe553e036ec8c031dc5b
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 91937
-  timestamp: 1666056461148
-- platform: osx-arm64
-  name: oauthlib
-  version: 3.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - blinker
-  - cryptography
-  - pyjwt >=1.0.0
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.2.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 8f882b197fd9c4941a787926baea4868
-    sha256: 0cfd5146a91d3974f4abfc2a45de890371d510a77238fe553e036ec8c031dc5b
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.2.2-pyhd8ed1ab_0.tar.bz2
+  sha256: 0cfd5146a91d3974f4abfc2a45de890371d510a77238fe553e036ec8c031dc5b
+  md5: 8f882b197fd9c4941a787926baea4868
+  depends:
+  - blinker
+  - cryptography
+  - pyjwt >=1.0.0
+  - python >=3.6
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/oauthlib
   size: 91937
   timestamp: 1666056461148
-- platform: linux-64
+- kind: pypi
+  name: open3d
+  version: 0.15.1
+  url: https://files.pythonhosted.org/packages/70/60/bd0553ded5d16d5834145184d4a53321fdf78c31b82c83764ef12b6d8c91/open3d-0.15.1-cp39-cp39-macosx_11_0_arm64.whl
+  sha256: 575e95884eca7f041ddf96a38e0bc6b2ba8f91d42fb60359e1c43e598d97b045
+  requires_dist:
+  - setuptools>=40.8.0
+  - wheel>=0.36.0
+  - numpy>=1.18.0
+  requires_python: '>=3.6'
+- kind: pypi
+  name: open3d
+  version: 0.18.0
+  url: https://files.pythonhosted.org/packages/e1/36/00032c1f99f67ec9d0afdb4bcb2561f78a9f5feaafdabd1043e12a6f9b6e/open3d-0.18.0-cp39-cp39-manylinux_2_27_x86_64.whl
+  sha256: 7d05fd6eedf75136cfbed24983da30bdfd08a6c4b1f968bf80ab84efc1fac861
+  requires_dist:
+  - numpy>=1.18.0
+  - dash>=2.6.0
+  - werkzeug>=2.2.3
+  - nbformat>=5.7.0
+  - configargparse
+  - ipywidgets>=8.0.4
+  - addict
+  - pillow>=9.3.0
+  - matplotlib>=3
+  - numpy>1.18
+  - pandas>=1.0
+  - pyyaml>=5.4.1
+  - scikit-learn>=0.21
+  - tqdm
+  - pyquaternion
+  - pywinpty==2.0.2 ; sys_platform == 'win32' and python_version == '3.6'
+  requires_python: '>=3.8'
+- kind: conda
   name: openh264
   version: 2.1.1
-  category: main
-  manager: conda
-  dependencies:
+  build: h780b84a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.1.1-h780b84a_0.tar.bz2
+  sha256: 2ce3df1edb23541595443c7697e5568ae6426fa4d365dede45b16b0310bd6a06
+  md5: 034a6f90f1bbc7ba11d04b84ec9d74c8
+  depends:
   - libgcc-ng >=9.3.0
   - libstdcxx-ng >=9.3.0
   - zlib >=1.2.11,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.1.1-h780b84a_0.tar.bz2
-  hash:
-    md5: 034a6f90f1bbc7ba11d04b84ec9d74c8
-    sha256: 2ce3df1edb23541595443c7697e5568ae6426fa4d365dede45b16b0310bd6a06
-  build: h780b84a_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   size: 1585354
   timestamp: 1609583081716
-- platform: osx-arm64
+- kind: conda
   name: openh264
   version: 2.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=14.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.3.1-hb7217d7_2.conda
-  hash:
-    md5: 6ce0517e73640933cf5916deb21d4f23
-    sha256: 36c6dc71bb10245ed93f3cb13280948cc8c6ca525f1639aac9d541726e4c80af
   build: hb7217d7_2
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.3.1-hb7217d7_2.conda
+  sha256: 36c6dc71bb10245ed93f3cb13280948cc8c6ca525f1639aac9d541726e4c80af
+  md5: 6ce0517e73640933cf5916deb21d4f23
+  depends:
+  - libcxx >=14.0.6
+  arch: aarch64
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 587729
   timestamp: 1675880932590
-- platform: linux-64
+- kind: conda
   name: openjpeg
   version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libpng >=1.6.39,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libtiff >=4.5.0,<4.6.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda
-  hash:
-    md5: 5ce6a42505c6e9e6151c54c3ec8d68ea
-    sha256: 3cbfb1fe9bb492dcb672f98f0ddc7b4e029f51f77101d9c301caa3acaea8cba2
-  build: hfec8fc6_2
-  arch: x86_64
-  subdir: linux-64
+  build: hbc2ba62_2
   build_number: 2
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 352022
-  timestamp: 1671435172657
-- platform: osx-arm64
-  name: openjpeg
-  version: 2.5.0
-  category: main
-  manager: conda
-  dependencies:
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-hbc2ba62_2.conda
+  sha256: 2bb159e385e633a08cc164f50b4e39fa465b85f54c376a5c20aa15f57ef407b3
+  md5: c3e184f0810a4614863569488b1ac709
+  depends:
   - libcxx >=14.0.6
   - libpng >=1.6.39,<1.7.0a0
   - libtiff >=4.5.0,<4.6.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-hbc2ba62_2.conda
-  hash:
-    md5: c3e184f0810a4614863569488b1ac709
-    sha256: 2bb159e385e633a08cc164f50b4e39fa465b85f54c376a5c20aa15f57ef407b3
-  build: hbc2ba62_2
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 2
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 307087
   timestamp: 1671435439914
-- platform: linux-64
+- kind: conda
+  name: openjpeg
+  version: 2.5.0
+  build: hfec8fc6_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda
+  sha256: 3cbfb1fe9bb492dcb672f98f0ddc7b4e029f51f77101d9c301caa3acaea8cba2
+  md5: 5ce6a42505c6e9e6151c54c3ec8d68ea
+  depends:
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.5.0,<4.6.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: x86_64
+  platform: linux
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 352022
+  timestamp: 1671435172657
+- kind: conda
   name: openssl
   version: 3.1.4
-  category: main
-  manager: conda
-  dependencies:
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
+  sha256: d15b3e83ce66c6f6fbb4707f2f5c53337124c01fb03bfda1cf25c5b41123efc7
+  md5: 412ba6938c3e2abaca8b1129ea82e238
+  depends:
   - ca-certificates
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
-  hash:
-    md5: 412ba6938c3e2abaca8b1129ea82e238
-    sha256: d15b3e83ce66c6f6fbb4707f2f5c53337124c01fb03bfda1cf25c5b41123efc7
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - pyopenssl >=22.1
+  arch: x86_64
+  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 2648006
   timestamp: 1698164814626
-- platform: osx-arm64
+- kind: conda
   name: openssl
   version: 3.2.0
-  category: main
-  manager: conda
-  dependencies:
-  - ca-certificates
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.0-h0d3ecfb_1.conda
-  hash:
-    md5: 47d16d26100f19ca495882882b7bc93b
-    sha256: a53e1c6c058b621fd1d13cca6f9cccd534d2b3f4b4ac789fe26f7902031d6c41
   build: h0d3ecfb_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.0-h0d3ecfb_1.conda
+  sha256: a53e1c6c058b621fd1d13cca6f9cccd534d2b3f4b4ac789fe26f7902031d6c41
+  md5: 47d16d26100f19ca495882882b7bc93b
+  depends:
+  - ca-certificates
   constrains:
   - pyopenssl >=22.1
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 2856233
   timestamp: 1701162541844
-- platform: linux-64
-  name: orc
-  version: 1.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libprotobuf >=4.23.3,<4.23.4.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.0-h385abfd_1.conda
-  hash:
-    md5: 2cd5aac7ef1b4c6ac51bf521251a89b3
-    sha256: bfd6af35afe7b8dfcc24721f05d5e3f9e8577105429c768f423a61f0fcc65105
-  build: h385abfd_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1020883
-  timestamp: 1688234533243
-- platform: osx-arm64
-  name: orc
-  version: 1.9.2
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.2-h7c018df_0.conda
-  hash:
-    md5: 1ef4159e9686d95ce8ea9f1d4d999f29
-    sha256: b1ad0f09dc69a8956079371d9853534f991f8311352e4e21503e6e5d20e4017b
-  build: h7c018df_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 405599
-  timestamp: 1700373052638
-- platform: osx-arm64
+- kind: conda
   name: p11-kit
   version: 0.24.1
-  category: main
-  manager: conda
-  dependencies:
+  build: h29577a5_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
+  sha256: 3e124859307956f9f390f39c74b9700be4843eaaf56891c4b09da75b1bd5b57f
+  md5: 8f111d56c8c7c1895bde91a942c43d93
+  depends:
   - libffi >=3.4.2,<3.5.0a0
   - libtasn1 >=4.18.0,<5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
-  hash:
-    md5: 8f111d56c8c7c1895bde91a942c43d93
-    sha256: 3e124859307956f9f390f39c74b9700be4843eaaf56891c4b09da75b1bd5b57f
-  build: h29577a5_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  platform: osx
   license: MIT
   license_family: MIT
   size: 890711
   timestamp: 1654869118646
-- platform: linux-64
+- kind: conda
   name: packaging
   version: '23.2'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 49452
-  timestamp: 1696202521121
-- platform: osx-arm64
-  name: packaging
-  version: '23.2'
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+  sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+  md5: 79002079284aa895f883c6b7f3f88fd6
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
+  purls:
+  - pkg:pypi/packaging
   size: 49452
   timestamp: 1696202521121
-- platform: linux-64
+- kind: pypi
+  name: pandas
+  version: 2.2.2
+  url: https://files.pythonhosted.org/packages/bb/30/f6f1f1ac36250f50c421b1b6af08c35e5a8b5a84385ef928625336b93e6f/pandas-2.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 66b479b0bd07204e37583c191535505410daa8df638fd8e75ae1b383851fe921
+  requires_dist:
+  - numpy>=1.22.4 ; python_version < '3.11'
+  - numpy>=1.23.2 ; python_version == '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - python-dateutil>=2.8.2
+  - pytz>=2020.1
+  - tzdata>=2022.7
+  - hypothesis>=6.46.1 ; extra == 'test'
+  - pytest>=7.3.2 ; extra == 'test'
+  - pytest-xdist>=2.2.0 ; extra == 'test'
+  - pyarrow>=10.0.1 ; extra == 'pyarrow'
+  - bottleneck>=1.3.6 ; extra == 'performance'
+  - numba>=0.56.4 ; extra == 'performance'
+  - numexpr>=2.8.4 ; extra == 'performance'
+  - scipy>=1.10.0 ; extra == 'computation'
+  - xarray>=2022.12.0 ; extra == 'computation'
+  - fsspec>=2022.11.0 ; extra == 'fss'
+  - s3fs>=2022.11.0 ; extra == 'aws'
+  - gcsfs>=2022.11.0 ; extra == 'gcp'
+  - pandas-gbq>=0.19.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.0 ; extra == 'excel'
+  - python-calamine>=0.1.7 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.0.5 ; extra == 'excel'
+  - pyarrow>=10.0.1 ; extra == 'parquet'
+  - pyarrow>=10.0.1 ; extra == 'feather'
+  - tables>=3.8.0 ; extra == 'hdf5'
+  - pyreadstat>=1.2.0 ; extra == 'spss'
+  - sqlalchemy>=2.0.0 ; extra == 'postgresql'
+  - psycopg2>=2.9.6 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.0 ; extra == 'mysql'
+  - pymysql>=1.0.2 ; extra == 'mysql'
+  - sqlalchemy>=2.0.0 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=0.8.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.11.2 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=4.9.2 ; extra == 'html'
+  - lxml>=4.9.2 ; extra == 'xml'
+  - matplotlib>=3.6.3 ; extra == 'plot'
+  - jinja2>=3.1.2 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.3.0 ; extra == 'clipboard'
+  - zstandard>=0.19.0 ; extra == 'compression'
+  - dataframe-api-compat>=0.1.7 ; extra == 'consortium-standard'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'all'
+  - adbc-driver-sqlite>=0.8.0 ; extra == 'all'
+  - beautifulsoup4>=4.11.2 ; extra == 'all'
+  - bottleneck>=1.3.6 ; extra == 'all'
+  - dataframe-api-compat>=0.1.7 ; extra == 'all'
+  - fastparquet>=2022.12.0 ; extra == 'all'
+  - fsspec>=2022.11.0 ; extra == 'all'
+  - gcsfs>=2022.11.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.46.1 ; extra == 'all'
+  - jinja2>=3.1.2 ; extra == 'all'
+  - lxml>=4.9.2 ; extra == 'all'
+  - matplotlib>=3.6.3 ; extra == 'all'
+  - numba>=0.56.4 ; extra == 'all'
+  - numexpr>=2.8.4 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.0 ; extra == 'all'
+  - pandas-gbq>=0.19.0 ; extra == 'all'
+  - psycopg2>=2.9.6 ; extra == 'all'
+  - pyarrow>=10.0.1 ; extra == 'all'
+  - pymysql>=1.0.2 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.0 ; extra == 'all'
+  - pytest>=7.3.2 ; extra == 'all'
+  - pytest-xdist>=2.2.0 ; extra == 'all'
+  - python-calamine>=0.1.7 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.3.0 ; extra == 'all'
+  - scipy>=1.10.0 ; extra == 'all'
+  - s3fs>=2022.11.0 ; extra == 'all'
+  - sqlalchemy>=2.0.0 ; extra == 'all'
+  - tables>=3.8.0 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2022.12.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.0.5 ; extra == 'all'
+  - zstandard>=0.19.0 ; extra == 'all'
+  requires_python: '>=3.9'
+- kind: pypi
+  name: parso
+  version: 0.8.4
+  url: https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl
+  sha256: a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18
+  requires_dist:
+  - flake8==5.0.4 ; extra == 'qa'
+  - mypy==0.971 ; extra == 'qa'
+  - types-setuptools==67.2.0.1 ; extra == 'qa'
+  - docopt ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  requires_python: '>=3.6'
+- kind: conda
   name: pcre2
   version: '10.42'
-  category: main
-  manager: conda
-  dependencies:
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
-  hash:
-    md5: 679c8961826aa4b50653bce17ee52abe
-    sha256: 3ca54ff0abcda964af7d4724d389ae20d931159ae1881cfe57ad4b0ab9e6a380
-  build: hcad00b1_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1017235
-  timestamp: 1698610864983
-- platform: osx-arm64
-  name: pcre2
-  version: '10.42'
-  category: main
-  manager: conda
-  dependencies:
-  - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.42-h26f9a81_0.conda
-  hash:
-    md5: 3e12888ecc8ee1ebee2eef9b7856357a
-    sha256: 0335a08349ecd8dce0b81699fcd61b58415e658fe953feb27316fbb994df0685
   build: h26f9a81_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.42-h26f9a81_0.conda
+  sha256: 0335a08349ecd8dce0b81699fcd61b58415e658fe953feb27316fbb994df0685
+  md5: 3e12888ecc8ee1ebee2eef9b7856357a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 619848
   timestamp: 1698610997157
-- platform: linux-64
+- kind: pypi
+  name: pexpect
+  version: 4.9.0
+  url: https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl
+  sha256: 7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523
+  requires_dist:
+  - ptyprocess>=0.5
+- kind: conda
   name: pillow
   version: 9.4.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py39h2320bf1_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.4.0-py39h2320bf1_1.conda
+  sha256: 77348588ae7cc8034b63e8a71b6695ba22761e1c531678e724cf06a12be3d1e2
+  md5: d2f79132b9c8e416058a4cd84ef27b3d
+  depends:
   - freetype >=2.12.1,<3.0a0
   - jpeg >=9e,<10a
   - lcms2 >=2.14,<3.0a0
@@ -7184,26 +4608,24 @@ package:
   - libxcb >=1.13,<1.14.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openjpeg >=2.5.0,<3.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   - tk >=8.6.12,<8.7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-9.4.0-py310h023d228_1.conda
-  hash:
-    md5: bbea829b541aa15df5c65bd40b8c1981
-    sha256: 6d17af4c8bc8d8668d033725dd4691cfac86fdf0f46f655ab6f5df3e3ae0bb7c
-  build: py310h023d228_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
   license: LicenseRef-PIL
-  size: 46458896
-  timestamp: 1675487348403
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/pillow
+  size: 46203066
+  timestamp: 1675487301925
+- kind: conda
   name: pillow
   version: 9.4.0
-  category: main
-  manager: conda
-  dependencies:
+  build: py39h8bd98a6_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.4.0-py39h8bd98a6_1.conda
+  sha256: 3005f4fc32c370c380abc692c027a1391ab8248798153cb2eca62dfc569912f7
+  md5: 90500f863712b55483294662f1f5f5f1
+  depends:
   - freetype >=2.12.1,<3.0a0
   - jpeg >=9e,<10a
   - lcms2 >=2.14,<3.0a0
@@ -7212,1073 +4634,525 @@ package:
   - libxcb >=1.13,<1.14.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openjpeg >=2.5.0,<3.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
   - tk >=8.6.12,<8.7.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.4.0-py310h5a7539a_1.conda
-  hash:
-    md5: b3c94458ef1002c937b89979c79eb486
-    sha256: dc1e74039820e86b876c4ad3563ab0522218dc978cf1fda34358eb640f950312
-  build: py310h5a7539a_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
   license: LicenseRef-PIL
-  size: 46538172
-  timestamp: 1675487797070
-- platform: linux-64
+  purls:
+  - pkg:pypi/pillow
+  size: 45733477
+  timestamp: 1675487630922
+- kind: pypi
   name: pip
-  version: 23.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - setuptools
-  - wheel
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2400c0b86889f43aa52067161e1fb108
-    sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 1398838
-  timestamp: 1697896918388
-- platform: osx-arm64
-  name: pip
-  version: 23.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  - setuptools
-  - wheel
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.3.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2400c0b86889f43aa52067161e1fb108
-    sha256: 435829a03e1c6009f013f29bb83de8b876c388820bf8cf69a7baeec25f6a3563
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 1398838
-  timestamp: 1697896918388
-- platform: linux-64
+  version: '24.0'
+  url: https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl
+  sha256: ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc
+  requires_python: '>=3.7'
+- kind: conda
   name: pixman
   version: 0.42.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.42.2-h59595ed_0.conda
-  hash:
-    md5: 700edd63ccd5fc66b70b1c028cea9a68
-    sha256: ae917851474eb3b08812b02c9e945d040808523ec53f828aa74a90b0cdf15f57
-  build: h59595ed_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 385309
-  timestamp: 1695736061006
-- platform: osx-arm64
-  name: pixman
-  version: 0.42.2
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.42.2-h13dd4ca_0.conda
-  hash:
-    md5: f96347021db6f33ccabe314ddeab62d4
-    sha256: 90e60dc5604e356d47ef97b23b13759ef3d8b70fa2c637f4809d29851435d7d7
   build: h13dd4ca_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.42.2-h13dd4ca_0.conda
+  sha256: 90e60dc5604e356d47ef97b23b13759ef3d8b70fa2c637f4809d29851435d7d7
+  md5: f96347021db6f33ccabe314ddeab62d4
+  depends:
+  - libcxx >=15.0.7
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 213843
   timestamp: 1695736518800
-- platform: linux-64
-  name: ply
-  version: '3.11'
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-py_1.tar.bz2
-  hash:
-    md5: 7205635cd71531943440fbfe3b6b5727
-    sha256: 2cd6fae8f9cbc806b7f828f006ae4a83c23fac917cacfd73c37ce322d4324e53
-  build: py_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: BSD 3-clause
-  license_family: BSD
-  noarch: python
-  size: 44837
-  timestamp: 1530963184592
-- platform: linux-64
-  name: protobuf
-  version: 4.23.3
-  category: main
-  manager: conda
-  dependencies:
-  - libabseil * cxx17*
-  - libabseil >=20230125.3,<20230126.0a0
-  - libgcc-ng >=12
-  - libprotobuf >=4.23.3,<4.23.4.0a0
-  - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - setuptools
-  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.23.3-py310hb875b13_0.conda
-  hash:
-    md5: 27ce7010f8821add3b955ec88f663bb6
-    sha256: b92f2c7728f1625003a247721af5b22c8100a92714596ce8158a07790221c40e
-  build: py310hb875b13_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 325773
-  timestamp: 1688121366252
-- platform: osx-arm64
+- kind: pypi
+  name: platformdirs
+  version: 4.2.2
+  url: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
+  sha256: 2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee
+  requires_dist:
+  - furo>=2023.9.10 ; extra == 'docs'
+  - proselint>=0.13 ; extra == 'docs'
+  - sphinx-autodoc-typehints>=1.25.2 ; extra == 'docs'
+  - sphinx>=7.2.6 ; extra == 'docs'
+  - appdirs==1.4.4 ; extra == 'test'
+  - covdefaults>=2.3 ; extra == 'test'
+  - pytest-cov>=4.1 ; extra == 'test'
+  - pytest-mock>=3.12 ; extra == 'test'
+  - pytest>=7.4.3 ; extra == 'test'
+  - mypy>=1.8 ; extra == 'type'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: plotly
+  version: 5.22.0
+  url: https://files.pythonhosted.org/packages/0b/f8/b65cdd2be32e442c4efe7b672f73c90b05eab5a7f3f4115efe181d432c60/plotly-5.22.0-py3-none-any.whl
+  sha256: 68fc1901f098daeb233cc3dd44ec9dc31fb3ca4f4e53189344199c43496ed006
+  requires_dist:
+  - tenacity>=6.2.0
+  - packaging
+  requires_python: '>=3.8'
+- kind: pypi
+  name: proglog
+  version: 0.1.10
+  url: https://files.pythonhosted.org/packages/8b/f5/cab5cf6a540c31f5099043de0ae43990fd9cf66f75ecb5e9f254a4e4d4ee/proglog-0.1.10-py3-none-any.whl
+  sha256: 19d5da037e8c813da480b741e3fa71fb1ac0a5b02bf21c41577c7f327485ec50
+  requires_dist:
+  - tqdm
+- kind: pypi
+  name: prompt-toolkit
+  version: 3.0.43
+  url: https://files.pythonhosted.org/packages/ee/fd/ca7bf3869e7caa7a037e23078539467b433a4e01eebd93f77180ab927766/prompt_toolkit-3.0.43-py3-none-any.whl
+  sha256: a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6
+  requires_dist:
+  - wcwidth
+  requires_python: '>=3.7.0'
+- kind: conda
   name: protobuf
   version: 4.24.4
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.9
+  build: py39h60f6b12_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.24.4-py39h60f6b12_0.conda
+  sha256: 191a019f70fa8819842a93e6e1d4a371c3e3926740a47c51a6b840d95a61f601
+  md5: c25d58de8c0408f157ce2937bf6d2043
+  depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=16.0.6
+  - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
+  - libstdcxx-ng >=12
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   - setuptools
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/protobuf-4.24.4-py310hc08086b_0.conda
-  hash:
-    md5: 8a5a1ed08789831ac01227be96835b49
-    sha256: fe0cb5cc88b9210b259e02c52b6667830cb67f95fdddca3a9f1dab8bc51d8994
-  build: py310hc08086b_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 307262
-  timestamp: 1696713098966
-- platform: linux-64
-  name: pthread-stubs
-  version: '0.4'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.5.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
-  hash:
-    md5: 22dad4df6e8630e8dff2428f6f6a7036
-    sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
-  build: h36c2ea0_1001
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1001
-  license: MIT
-  license_family: MIT
-  size: 5625
-  timestamp: 1606147468727
-- platform: osx-arm64
-  name: pthread-stubs
-  version: '0.4'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
-  hash:
-    md5: d3f26c6494d4105d4ecb85203d687102
-    sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
-  build: h27ca646_1001
-  arch: aarch64
+  purls:
+  - pkg:pypi/protobuf
+  size: 328609
+  timestamp: 1696712921014
+- kind: conda
+  name: protobuf
+  version: 4.25.1
+  build: py39haf112ec_0
   subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/protobuf-4.25.1-py39haf112ec_0.conda
+  sha256: c3bf92bd35326800f864b6c0aced7e294c3d52c25a34d2f0f5dbc4ecd07f1bb0
+  md5: 24417d997e5daaf93f59c604eec97282
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=15
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/protobuf
+  size: 309024
+  timestamp: 1705903324358
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: h27ca646_1001
   build_number: 1001
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+  sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
+  md5: d3f26c6494d4105d4ecb85203d687102
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 5696
   timestamp: 1606147608402
-- platform: linux-64
-  name: pulseaudio
-  version: '16.1'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - pulseaudio-client 16.1 h5195f5e_3
-  - pulseaudio-daemon 16.1 ha8d29e2_3
-  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-16.1-hcb278e6_3.conda
-  hash:
-    md5: 8b452ab959166d91949af4c2d28f81db
-    sha256: 59f58bbe5ead04537ffcd6262674daf71e9702e88d1c142a38dcd641b4eab936
-  build: hcb278e6_3
-  arch: x86_64
+- kind: conda
+  name: pthread-stubs
+  version: '0.4'
+  build: h36c2ea0_1001
+  build_number: 1001
   subdir: linux-64
-  build_number: 3
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 16628
-  timestamp: 1679504551442
-- platform: linux-64
-  name: pulseaudio-client
-  version: '16.1'
-  category: main
-  manager: conda
-  dependencies:
-  - dbus >=1.13.6,<2.0a0
-  - libgcc-ng >=12
-  - libglib >=2.74.1,<3.0a0
-  - libsndfile >=1.2.0,<1.3.0a0
-  - libsystemd0 >=253
-  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-h5195f5e_3.conda
-  hash:
-    md5: caeb3302ef1dc8b342b20c710a86f8a9
-    sha256: da289229ca472fa17f5c194c86362354f6dc66311502bb44959a93e7bb88e320
-  build: h5195f5e_3
+  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+  sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+  md5: 22dad4df6e8630e8dff2428f6f6a7036
+  depends:
+  - libgcc-ng >=7.5.0
   arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  constrains:
-  - pulseaudio 16.1 *_3
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 752233
-  timestamp: 1679504427309
-- platform: linux-64
-  name: pulseaudio-daemon
-  version: '16.1'
-  category: main
-  manager: conda
-  dependencies:
-  - alsa-lib >=1.2.8,<1.2.9.0a0
-  - dbus >=1.13.6,<2.0a0
-  - fftw >=3.3.10,<4.0a0
-  - gstreamer-orc >=0.4.33,<0.5.0a0
-  - jack >=1.9.22,<1.10.0a0
-  - libcap >=2.67,<2.68.0a0
-  - libgcc-ng >=12
-  - libglib >=2.74.1,<3.0a0
-  - libsndfile >=1.2.0,<1.3.0a0
-  - libsystemd0 >=253
-  - libtool >=2.4.7,<3.0a0
-  - libudev1 >=253
-  - openssl >=3.1.0,<4.0a0
-  - pulseaudio-client 16.1 h5195f5e_3
-  url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-daemon-16.1-ha8d29e2_3.conda
-  hash:
-    md5: 34d9d75ca896f5919c372a34e25f23ea
-    sha256: ce549c137b7d2711a6fe65d07ca9926fe267143d1c72c3f75d058470391c2ed2
-  build: ha8d29e2_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  constrains:
-  - pulseaudio 16.1 *_3
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 848588
-  timestamp: 1679504539092
-- platform: linux-64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 5625
+  timestamp: 1606147468727
+- kind: pypi
+  name: ptyprocess
+  version: 0.7.0
+  url: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
+  sha256: 4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35
+- kind: pypi
+  name: pure-eval
+  version: 0.2.2
+  url: https://files.pythonhosted.org/packages/2b/27/77f9d5684e6bce929f5cfe18d6cfbe5133013c06cb2fbf5933670e60761d/pure_eval-0.2.2-py3-none-any.whl
+  sha256: 01eaab343580944bc56080ebe0a674b39ec44a945e6d09ba7db3cb8cec289350
+  requires_dist:
+  - pytest ; extra == 'tests'
+- kind: pypi
   name: pyarrow
-  version: 10.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - gflags >=2.2.2,<2.3.0a0
-  - libarrow 10.0.1 *_36_cpu
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - numpy >=1.21.6,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-10.0.1-py310he6bfd7f_36_cpu.conda
-  hash:
-    md5: db77084912748153539f7f1fd3fabc63
-    sha256: b1d17798296be9933e2b54777f643e7ab66564140bf5b5b6b875b9611f3de374
-  build: py310he6bfd7f_36_cpu
-  arch: x86_64
-  subdir: linux-64
-  build_number: 36
-  constrains:
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3822109
-  timestamp: 1690573294998
-- platform: osx-arm64
+  version: 16.1.0
+  url: https://files.pythonhosted.org/packages/e3/12/635c509b84c50cd92fa35a2dee8bc9c1f6fc042da86276ca726f24c5d87f/pyarrow-16.1.0-cp39-cp39-macosx_11_0_arm64.whl
+  sha256: 99f7549779b6e434467d2aa43ab2b7224dd9e41bdde486020bae198978c9e05e
+  requires_dist:
+  - numpy>=1.16.6
+  requires_python: '>=3.8'
+- kind: pypi
   name: pyarrow
-  version: 10.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - gflags >=2.2.2,<2.3.0a0
-  - libarrow 10.0.1 h9be0040_57_cpu
-  - libcxx >=14.0.6
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-10.0.1-py310h0b8b8ad_57_cpu.conda
-  hash:
-    md5: 2aad7b1c93d5de090347a21acfe4c591
-    sha256: 1d5cfa99d05087a3906248f3bc13b9555e60625db9fb7098d28b43d6c816aff3
-  build: py310h0b8b8ad_57_cpu
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 57
-  constrains:
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2950501
-  timestamp: 1701296135835
-- platform: linux-64
+  version: 16.1.0
+  url: https://files.pythonhosted.org/packages/4a/0e/ca72b2e27d8d7a23e9866c819436ebeb518f934ac2b8b871fab373f9c859/pyarrow-16.1.0-cp39-cp39-manylinux_2_28_x86_64.whl
+  sha256: ba8ac20693c0bb0bf4b238751d4409e62852004a8cf031c73b0e0962b03e45e3
+  requires_dist:
+  - numpy>=1.16.6
+  requires_python: '>=3.8'
+- kind: conda
   name: pyasn1
   version: 0.5.1
-  category: main
-  manager: conda
-  dependencies:
-  - python !=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: fb1a800972b072aa4d16450983c81418
-    sha256: 8b116da9acbb471e107203c11acaffcb259aca2367aa7e83e796e43ed5d381b3
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.5.1-pyhd8ed1ab_0.conda
+  sha256: 8b116da9acbb471e107203c11acaffcb259aca2367aa7e83e796e43ed5d381b3
+  md5: fb1a800972b072aa4d16450983c81418
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5
+  arch: aarch64
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/pyasn1
   size: 63586
   timestamp: 1701287134208
-- platform: osx-arm64
-  name: pyasn1
-  version: 0.5.1
-  category: main
-  manager: conda
-  dependencies:
-  - python !=3.0,!=3.1,!=3.2,!=3.3,!=3.4,!=3.5
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.5.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: fb1a800972b072aa4d16450983c81418
-    sha256: 8b116da9acbb471e107203c11acaffcb259aca2367aa7e83e796e43ed5d381b3
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 63586
-  timestamp: 1701287134208
-- platform: linux-64
+- kind: conda
   name: pyasn1-modules
   version: 0.3.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.3.0-pyhd8ed1ab_0.conda
+  sha256: 7867ba43b6ef1e66054ca6b70f59bbef4cdb0cc761f0be3b66d79d15bd43143b
+  md5: 26db749166cdca55e5ef1ffdc7767d0e
+  depends:
   - pyasn1 >=0.4.6,<0.6.0
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 26db749166cdca55e5ef1ffdc7767d0e
-    sha256: 7867ba43b6ef1e66054ca6b70f59bbef4cdb0cc761f0be3b66d79d15bd43143b
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/pyasn1-modules
   size: 95605
   timestamp: 1695108003656
-- platform: osx-arm64
-  name: pyasn1-modules
-  version: 0.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - pyasn1 >=0.4.6,<0.6.0
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 26db749166cdca55e5ef1ffdc7767d0e
-    sha256: 7867ba43b6ef1e66054ca6b70f59bbef4cdb0cc761f0be3b66d79d15bd43143b
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 95605
-  timestamp: 1695108003656
-- platform: linux-64
+- kind: conda
   name: pycparser
   version: '2.21'
-  category: main
-  manager: conda
-  dependencies:
-  - python ==2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+  sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+  md5: 076becd9e05608f8dc72757d5f3a91ff
+  depends:
+  - python ==2.7.*|>=3.4
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/pycparser
   size: 102747
   timestamp: 1636257201998
-- platform: osx-arm64
-  name: pycparser
-  version: '2.21'
-  category: main
-  manager: conda
-  dependencies:
-  - python ==2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 102747
-  timestamp: 1636257201998
-- platform: linux-64
+- kind: conda
   name: pydeprecate
   version: 0.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pydeprecate-0.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 42926d3d9945b1212fc0acbd6a5624ad
-    sha256: 7a62051c2b518ebad2e126725fe506c349ea99f57652ec34c402ce139e61be03
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pydeprecate-0.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 7a62051c2b518ebad2e126725fe506c349ea99f57652ec34c402ce139e61be03
+  md5: 42926d3d9945b1212fc0acbd6a5624ad
+  depends:
+  - python >=3.6
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/pydeprecate
   size: 13407
   timestamp: 1622496377561
-- platform: osx-arm64
-  name: pydeprecate
-  version: 0.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pydeprecate-0.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 42926d3d9945b1212fc0acbd6a5624ad
-    sha256: 7a62051c2b518ebad2e126725fe506c349ea99f57652ec34c402ce139e61be03
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 13407
-  timestamp: 1622496377561
-- platform: linux-64
+- kind: pypi
   name: pyglet
-  version: 1.5.27
-  category: main
-  manager: conda
-  dependencies:
-  - ffmpeg >=4,<6
-  - freetype
-  - future
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyglet-1.5.27-py310hff52083_4.conda
-  hash:
-    md5: ea38b57e303cdef584057bc971b9852a
-    sha256: 85ab875b1f068d5910921266507a234471c721a6c8ef2c0e87d713f59cec44a7
-  build: py310hff52083_4
-  arch: x86_64
-  subdir: linux-64
-  build_number: 4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1378915
-  timestamp: 1695497779257
-- platform: osx-arm64
-  name: pyglet
-  version: 1.5.27
-  category: main
-  manager: conda
-  dependencies:
-  - ffmpeg >=4,<6
-  - freetype
-  - future
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyglet-1.5.27-py310hbe9552e_4.conda
-  hash:
-    md5: c3bed8e7d8ecb0c4a7d5ee81367be35c
-    sha256: 3bef3c00fb82c2cb2aff41ff88f7f79b64a9f78f92aec515c299197e27d1655c
-  build: py310hbe9552e_4
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 4
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1381463
-  timestamp: 1695497945652
-- platform: linux-64
+  version: 2.0.15
+  url: https://files.pythonhosted.org/packages/30/93/4d02ac696f16a2ad8fff0e78be28ab4ec0b990d2b3569fe07e27a258cb02/pyglet-2.0.15-py3-none-any.whl
+  sha256: 9e4cc16efc308106fd3a9ff8f04e7a6f4f6a807c6ac8a331375efbbac8be85af
+  requires_python: '>=3.8'
+- kind: pypi
+  name: pygments
+  version: 2.18.0
+  url: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
+  sha256: b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a
+  requires_dist:
+  - colorama>=0.4.6 ; extra == 'windows-terminal'
+  requires_python: '>=3.8'
+- kind: conda
   name: pyjwt
   version: 2.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 912c0194f898fdb783021fd25f913c31
-    sha256: 88ac94c42ade15113397e30d1831dd341399b5262fb5330b9240f915c33cd232
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_0.conda
+  sha256: 88ac94c42ade15113397e30d1831dd341399b5262fb5330b9240f915c33cd232
+  md5: 912c0194f898fdb783021fd25f913c31
+  depends:
+  - python >=3.6
   constrains:
   - cryptography >=3.3.1
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/pyjwt
   size: 24809
   timestamp: 1689721740099
-- platform: osx-arm64
-  name: pyjwt
-  version: 2.8.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 912c0194f898fdb783021fd25f913c31
-    sha256: 88ac94c42ade15113397e30d1831dd341399b5262fb5330b9240f915c33cd232
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  constrains:
-  - cryptography >=3.3.1
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 24809
-  timestamp: 1689721740099
-- platform: linux-64
+- kind: pypi
   name: pyopengl
-  version: 3.1.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopengl-3.1.6-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c968eb974b0fae4676e7a7858c4cc56e
-    sha256: 4ef77f5227e198b20c1498706fa6b3eb3a32f1cef641b8039d55b7df12e54863
-  build: pyhd8ed1ab_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: LicenseRef-pyopengl
-  noarch: python
-  size: 887829
-  timestamp: 1652285640360
-- platform: osx-arm64
-  name: pyopengl
-  version: 3.1.6
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopengl-3.1.6-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: c968eb974b0fae4676e7a7858c4cc56e
-    sha256: 4ef77f5227e198b20c1498706fa6b3eb3a32f1cef641b8039d55b7df12e54863
-  build: pyhd8ed1ab_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: LicenseRef-pyopengl
-  noarch: python
-  size: 887829
-  timestamp: 1652285640360
-- platform: linux-64
+  version: 3.1.0
+  url: https://files.pythonhosted.org/packages/9c/1d/4544708aaa89f26c97cc09450bb333a23724a320923e74d73e028b3560f9/PyOpenGL-3.1.0.tar.gz
+  sha256: 9b47c5c3a094fa518ca88aeed35ae75834d53e4285512c61879f67a48c94ddaf
+- kind: conda
   name: pyopenssl
-  version: 23.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - cryptography >=41.0.5,<42
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7819533e674dbbc51468f3228b9b1bb6
-    sha256: f7e04c4a49b1593140231d70801e2204e314e26d7141bfbdc8089d04114c0010
+  version: 24.0.0
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-24.0.0-pyhd8ed1ab_0.conda
+  sha256: bacd1d38585f447e2809e7621283661da7c97cfa20f545edb0ac5838356ed87b
+  md5: b50aec2c744a5c493c09cce9e2e7533e
+  depends:
+  - cryptography >=41.0.5,<43
+  - python >=3.7
   license: Apache-2.0
   license_family: Apache
-  noarch: python
-  size: 127052
-  timestamp: 1698795615331
-- platform: osx-arm64
-  name: pyopenssl
-  version: 23.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - cryptography >=41.0.5,<42
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7819533e674dbbc51468f3228b9b1bb6
-    sha256: f7e04c4a49b1593140231d70801e2204e314e26d7141bfbdc8089d04114c0010
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  noarch: python
-  size: 127052
-  timestamp: 1698795615331
-- platform: linux-64
+  purls:
+  - pkg:pypi/pyopenssl
+  size: 127070
+  timestamp: 1706660212326
+- kind: pypi
   name: pyparsing
-  version: 3.1.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
-    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 89521
-  timestamp: 1690737983548
-- platform: osx-arm64
-  name: pyparsing
-  version: 3.1.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
-    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 89521
-  timestamp: 1690737983548
-- platform: linux-64
-  name: pyqt
-  version: 5.15.9
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pyqt5-sip 12.12.2 py310hc6cd4ac_5
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py310h04931ad_5.conda
-  hash:
-    md5: f4fe7a6e3d7c78c9de048ea9dda21690
-    sha256: 92fe1c9eda6be7879ba798066016c1065047cc13d730105f5109835cbfeae8f1
-  build: py310h04931ad_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 5282574
-  timestamp: 1695420653225
-- platform: linux-64
-  name: pyqt5-sip
-  version: 12.12.2
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - packaging
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - sip
-  - toml
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.12.2-py310hc6cd4ac_5.conda
-  hash:
-    md5: ef5333594a958b25912002886b82b253
-    sha256: a6aec078683ed3cf1650b7c47e3f0fe185015d54ea37fe76b9f31f05e1fd087d
-  build: py310hc6cd4ac_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 84579
-  timestamp: 1695418069976
-- platform: linux-64
+  version: 3.1.2
+  url: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
+  sha256: f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742
+  requires_dist:
+  - railroad-diagrams ; extra == 'diagrams'
+  - jinja2 ; extra == 'diagrams'
+  requires_python: '>=3.6.8'
+- kind: pypi
+  name: pyquaternion
+  version: 0.9.9
+  url: https://files.pythonhosted.org/packages/49/b3/d8482e8cacc8ea15a356efea13d22ce1c5914a9ee36622ba250523240bf2/pyquaternion-0.9.9-py3-none-any.whl
+  sha256: e65f6e3f7b1fdf1a9e23f82434334a1ae84f14223eee835190cd2e841f8172ec
+  requires_dist:
+  - numpy
+  - mkdocs ; extra == 'dev'
+  - nose ; extra == 'test'
+- kind: pypi
   name: pyrender
   version: 0.1.45
-  category: main
-  manager: conda
-  dependencies:
-  - dataclasses
+  url: https://files.pythonhosted.org/packages/28/88/174c28b9d3d03cf6d8edb6f637458f30f1cf1a2bd7a617cbd9dadb1740f6/pyrender-0.1.45-py3-none-any.whl
+  sha256: 5cf751d1f21fba4640e830cef3a0b5a95ed0f05677bf92c6b8330056b4023aeb
+  requires_dist:
   - freetype-py
   - imageio
   - networkx
   - numpy
   - pillow
-  - pyglet >=1.4.10
-  - pyopengl >=3.1.0
-  - python >=3.6
+  - pyglet>=1.4.10
+  - pyopengl==3.1.0
   - scipy
   - six
   - trimesh
-  url: https://conda.anaconda.org/conda-forge/noarch/pyrender-0.1.45-pyh8a188c0_3.tar.bz2
-  hash:
-    md5: 54eeab066e4b838e18000382d59512f6
-    sha256: 90d78f81d76b28fc63ee2e99c52dd7692afec31c4d8bb0a0d23b0bf36ea0a875
-  build: pyh8a188c0_3
-  arch: x86_64
-  subdir: linux-64
-  build_number: 3
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 36091137
-  timestamp: 1656506457149
-- platform: osx-arm64
-  name: pyrender
-  version: 0.1.45
-  category: main
-  manager: conda
-  dependencies:
-  - dataclasses
-  - freetype-py
-  - imageio
-  - networkx
-  - numpy
-  - pillow
-  - pyglet >=1.4.10
-  - pyopengl >=3.1.0
-  - python >=3.6
-  - scipy
-  - six
-  - trimesh
-  url: https://conda.anaconda.org/conda-forge/noarch/pyrender-0.1.45-pyh8a188c0_3.tar.bz2
-  hash:
-    md5: 54eeab066e4b838e18000382d59512f6
-    sha256: 90d78f81d76b28fc63ee2e99c52dd7692afec31c4d8bb0a0d23b0bf36ea0a875
-  build: pyh8a188c0_3
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 3
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 36091137
-  timestamp: 1656506457149
-- platform: linux-64
+  - flake8 ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-cov ; extra == 'dev'
+  - tox ; extra == 'dev'
+  - sphinx ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - sphinx-automodapi ; extra == 'docs'
+- kind: conda
   name: pysocks
   version: 1.7.1
-  category: main
-  manager: conda
-  dependencies:
-  - __unix
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
-  hash:
-    md5: 2a7de29fb590ca14b5243c4c812c8025
-    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
   build: pyha2e5f31_6
-  arch: x86_64
-  subdir: linux-64
   build_number: 6
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 18981
-  timestamp: 1661604969727
-- platform: osx-arm64
-  name: pysocks
-  version: 1.7.1
-  category: main
-  manager: conda
-  dependencies:
-  - __unix
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
-  hash:
-    md5: 2a7de29fb590ca14b5243c4c812c8025
-    sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
-  build: pyha2e5f31_6
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 6
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
+  sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+  md5: 2a7de29fb590ca14b5243c4c812c8025
+  depends:
+  - __unix
+  - python >=3.8
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/pysocks
   size: 18981
   timestamp: 1661604969727
-- platform: linux-64
+- kind: conda
   name: python
-  version: 3.10.13
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.9.18
+  build: h0755675_0_cpython
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.18-h0755675_0_cpython.conda
+  sha256: 18db2220328abee8eb19f51c8df88bcfdf3a557b8181e7f5bda291deb067e40f
+  md5: 3ede353bc605068d9677e700b1847382
+  depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.43.2,<4.0a0
+  - libnsl >=2.0.0,<2.1.0a0
+  - libsqlite >=3.43.0,<4.0a0
   - libuuid >=2.38.1,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.1.2,<4.0a0
   - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
+  - tk >=8.6.12,<8.7.0a0
   - tzdata
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_0_cpython.conda
-  hash:
-    md5: f3a8c32aa764c3e7188b4b810fc9d6ce
-    sha256: a53410f459f314537b379982717b1c5911efc2f0cc26d63c4d6f831bcb31c964
-  build: hd12c33a_0_cpython
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
-  - python_abi 3.10.* *_cp310
+  - python_abi 3.9.* *_cp39
   license: Python-2.0
-  size: 25476977
-  timestamp: 1698344640413
-- platform: osx-arm64
+  size: 23778664
+  timestamp: 1693368468682
+- kind: conda
   name: python
-  version: 3.10.13
-  category: main
-  manager: conda
-  dependencies:
+  version: 3.9.18
+  build: hd7ebdb9_1_cpython
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.18-hd7ebdb9_1_cpython.conda
+  sha256: 7336d2cfefff2466f1f60144f10f5bf98f9d176a8c72ca85336baa5dc32299ef
+  md5: c48f67fd7147f37c941037de0a328560
+  depends:
   - bzip2 >=1.0.8,<2.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.2,<4.0a0
+  - libsqlite >=3.44.2,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.13-h2469fbe_0_cpython.conda
-  hash:
-    md5: c962b55e55a14d30f61fe11b84c2b319
-    sha256: beac97704e80948a3bacba7001737a99e3908006aa6461d5564755854959eba2
-  build: h2469fbe_0_cpython
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
   constrains:
-  - python_abi 3.10.* *_cp310
+  - python_abi 3.9.* *_cp39
   license: Python-2.0
-  size: 11522758
-  timestamp: 1698344110843
-- platform: linux-64
+  size: 11822452
+  timestamp: 1703349662775
+- kind: pypi
   name: python-dateutil
-  version: 2.8.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  - six >=1.5
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd999d1cc9f79e67dbb855c8924c7984
-    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 245987
-  timestamp: 1626286448716
-- platform: osx-arm64
-  name: python-dateutil
-  version: 2.8.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.6
-  - six >=1.5
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd999d1cc9f79e67dbb855c8924c7984
-    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 245987
-  timestamp: 1626286448716
-- platform: linux-64
+  version: 2.9.0.post0
+  url: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+  sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+  requires_dist:
+  - six>=1.5
+  requires_python: '!=3.0.*,!=3.1.*,!=3.2.*,>=2.7'
+- kind: conda
   name: python_abi
-  version: '3.10'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
-  hash:
-    md5: 26322ec5d7712c3ded99dd656142b8ce
-    sha256: 456bec815bfc2b364763084d08b412fdc4c17eb9ccc66a36cb775fa7ac3cbaec
-  build: 4_cp310
-  arch: x86_64
-  subdir: linux-64
+  version: '3.9'
+  build: 4_cp39
   build_number: 4
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.9-4_cp39.conda
+  sha256: 7e0157e35929711e1a986c18a8bfb7a38a2209cfada16b541ebb0481f74376d6
+  md5: bfe4b3259a8ac6cdf0037752904da6a7
   constrains:
-  - python 3.10.* *_cpython
+  - python 3.9.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6398
-  timestamp: 1695147363189
-- platform: osx-arm64
+  size: 6378
+  timestamp: 1695147399237
+- kind: conda
   name: python_abi
-  version: '3.10'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.10-4_cp310.conda
-  hash:
-    md5: 1a3d9c6bb5f0b1b22d9e9296c127e8c7
-    sha256: f69bac2f28082a275ef67313968b2c366d8236c3a6869b9cdf5cdb97a5821812
-  build: 4_cp310
-  arch: aarch64
-  subdir: osx-arm64
+  version: '3.9'
+  build: 4_cp39
   build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.9-4_cp39.conda
+  sha256: 2ae06dcd1a03f023b6accf5bd989f42b689f708d3495affa22c2ed9f1d127726
+  md5: be9e11a37bbab9cfdbcb36e52d8d73cb
   constrains:
-  - python 3.10.* *_cpython
+  - python 3.9.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6490
-  timestamp: 1695147522999
-- platform: linux-64
+  size: 6484
+  timestamp: 1695147719187
+- kind: conda
   name: pytorch
   version: 1.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - blas * mkl
-  - mkl >=2018
-  - python >=3.10,<3.11.0a0
-  - pytorch-cuda >=11.7,<11.8
-  - pytorch-mutex 1.0 cuda
-  - typing_extensions
-  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-1.13.1-py3.10_cuda11.7_cudnn8.5.0_0.tar.bz2
-  hash:
-    md5: 08cd4b8e4fef95a1f4c5eca46c9cea86
-    sha256: 5436468b810e477fbf3d07f4c9b2ff52ae25d1cba91955c49f7e8877bbf5965e
-  build: py3.10_cuda11.7_cudnn8.5.0_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - cpuonly <0
-  license: BSD 3-Clause
-  license_family: BSD
-  size: 1227164233
-  timestamp: 1670533513319
-- platform: osx-arm64
-  name: pytorch
-  version: 1.13.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.10,<3.11.0a0
-  - typing_extensions
-  url: https://conda.anaconda.org/pytorch/osx-arm64/pytorch-1.13.1-py3.10_0.tar.bz2
-  hash:
-    md5: c25ac069a1eb43985d696eb5396b5863
-    sha256: 8158750161d565df1db2c56160a586c4b06abd37faa109780b33c6ec0803abd4
-  build: py3.10_0
-  arch: aarch64
+  build: py3.9_0
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/pytorch/osx-arm64/pytorch-1.13.1-py3.9_0.tar.bz2
+  sha256: e61fa6327b73f8dd85468e6691a41c0df0cbff42afbed9fe856dbac5ea849d4b
+  md5: 9af32b4a87810a99bb9c49e92830e44a
+  depends:
+  - python >=3.9,<3.10.0a0
+  - typing_extensions
   constrains:
   - cpuonly
   license: BSD 3-Clause
   license_family: BSD
-  size: 46387844
-  timestamp: 1670528031142
-- platform: linux-64
+  purls:
+  - pkg:pypi/torch
+  size: 46233441
+  timestamp: 1670528554375
+- kind: conda
+  name: pytorch
+  version: 1.13.1
+  build: py3.9_cuda11.7_cudnn8.5.0_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-1.13.1-py3.9_cuda11.7_cudnn8.5.0_0.tar.bz2
+  sha256: f078ee258a1a8084c72a9737f462e739cfabc1d634b5661e03d6efcb453ac305
+  md5: 9704aa36a7c4051d3fd3c8eb83e38e97
+  depends:
+  - blas * mkl
+  - mkl >=2018
+  - python >=3.9,<3.10.0a0
+  - pytorch-cuda >=11.7,<11.8
+  - pytorch-mutex 1.0 cuda
+  - typing_extensions
+  constrains:
+  - cpuonly <0
+  license: BSD 3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/torch
+  size: 1226415177
+  timestamp: 1670533387153
+- kind: conda
   name: pytorch-cuda
   version: '11.7'
-  category: main
-  manager: conda
-  dependencies:
+  build: h778d358_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-cuda-11.7-h778d358_5.tar.bz2
+  sha256: 526683e5eff9047a0e1a2d26da7712f5ee18fc487555e6b99decca32400890a8
+  md5: bba2918836f9fe6c1b518256dda67dee
+  depends:
   - cuda-cudart >=11.7,<11.8
   - cuda-cupti >=11.7,<11.8
   - cuda-libraries >=11.7,<11.8
@@ -8291,623 +5165,563 @@ package:
   - libcusparse >=11.7.3.50,<11.7.5.86
   - libnpp >=11.7.3.21,<11.8.0.86
   - libnvjpeg >=11.7.2.34,<11.9.0.86
-  url: https://conda.anaconda.org/pytorch/linux-64/pytorch-cuda-11.7-h778d358_5.tar.bz2
-  hash:
-    md5: bba2918836f9fe6c1b518256dda67dee
-    sha256: 526683e5eff9047a0e1a2d26da7712f5ee18fc487555e6b99decca32400890a8
-  build: h778d358_5
   arch: x86_64
-  subdir: linux-64
-  build_number: 5
+  platform: linux
   size: 3561
   timestamp: 1682528123948
-- platform: linux-64
+- kind: conda
   name: pytorch-lightning
   version: 1.5.4
-  category: main
-  manager: conda
-  dependencies:
-  - fsspec >=2021.05.0,!=2021.06.0
-  - future
-  - numpy >=1.17.2
-  - packaging
-  - pydeprecate 0.3.1
-  - python >=3.6
-  - pytorch >=1.6
-  - pyyaml >=5.1
-  - tensorboard >=2.2.0
-  - torchmetrics >=0.4.1
-  - tqdm >=4.41.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytorch-lightning-1.5.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3e6e23a451d6c3371cb11736c9a00a28
-    sha256: ce10c0db6ec451304bc15b13a74985a89fce2b58005c76b16269cacb4108e6a2
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 303457
-  timestamp: 1638308989571
-- platform: osx-arm64
-  name: pytorch-lightning
-  version: 1.5.4
-  category: main
-  manager: conda
-  dependencies:
-  - fsspec >=2021.05.0,!=2021.06.0
-  - future
-  - numpy >=1.17.2
-  - packaging
-  - pydeprecate 0.3.1
-  - python >=3.6
-  - pytorch >=1.6
-  - pyyaml >=5.1
-  - tensorboard >=2.2.0
-  - torchmetrics >=0.4.1
-  - tqdm >=4.41.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytorch-lightning-1.5.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3e6e23a451d6c3371cb11736c9a00a28
-    sha256: ce10c0db6ec451304bc15b13a74985a89fce2b58005c76b16269cacb4108e6a2
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytorch-lightning-1.5.4-pyhd8ed1ab_0.tar.bz2
+  sha256: ce10c0db6ec451304bc15b13a74985a89fce2b58005c76b16269cacb4108e6a2
+  md5: 3e6e23a451d6c3371cb11736c9a00a28
+  depends:
+  - fsspec >=2021.05.0,!=2021.06.0
+  - future
+  - numpy >=1.17.2
+  - packaging
+  - pydeprecate 0.3.1
+  - python >=3.6
+  - pytorch >=1.6
+  - pyyaml >=5.1
+  - tensorboard >=2.2.0
+  - torchmetrics >=0.4.1
+  - tqdm >=4.41.0
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
+  purls:
+  - pkg:pypi/pytorch-lightning
   size: 303457
   timestamp: 1638308989571
-- platform: linux-64
+- kind: conda
   name: pytorch-mutex
   version: '1.0'
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
-  hash:
-    md5: a948316e36fb5b11223b3fcfa93f8358
-    sha256: c16316183f51b74ca5eee4dcb8631052f328c0bbf244176734a0b7d390b81ee3
   build: cuda
-  arch: x86_64
-  subdir: linux-64
   build_number: 100
+  subdir: linux-64
   noarch: generic
+  url: https://conda.anaconda.org/pytorch/noarch/pytorch-mutex-1.0-cuda.tar.bz2
+  sha256: c16316183f51b74ca5eee4dcb8631052f328c0bbf244176734a0b7d390b81ee3
+  md5: a948316e36fb5b11223b3fcfa93f8358
+  arch: x86_64
+  platform: linux
   size: 2906
   timestamp: 1628062930777
-- platform: linux-64
+- kind: pypi
+  name: pytz
+  version: '2024.1'
+  url: https://files.pythonhosted.org/packages/9c/3d/a121f284241f08268b21359bd425f7d4825cffc5ac5cd0e1b3d82ffd2b10/pytz-2024.1-py2.py3-none-any.whl
+  sha256: 328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319
+- kind: conda
   name: pyu2f
   version: 0.1.5
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pyu2f-0.1.5-pyhd8ed1ab_0.tar.bz2
+  sha256: 667a5a30b65a60b15f38fa4cb09efd6d2762b5a0a9563acd9555eaa5e0b953a2
+  md5: caabbeaa83928d0c3e3949261daa18eb
+  depends:
   - python >=2.7
   - six
-  url: https://conda.anaconda.org/conda-forge/noarch/pyu2f-0.1.5-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: caabbeaa83928d0c3e3949261daa18eb
-    sha256: 667a5a30b65a60b15f38fa4cb09efd6d2762b5a0a9563acd9555eaa5e0b953a2
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
+  purls:
+  - pkg:pypi/pyu2f
   size: 31876
   timestamp: 1604249020971
-- platform: osx-arm64
-  name: pyu2f
-  version: 0.1.5
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  - six
-  url: https://conda.anaconda.org/conda-forge/noarch/pyu2f-0.1.5-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: caabbeaa83928d0c3e3949261daa18eb
-    sha256: 667a5a30b65a60b15f38fa4cb09efd6d2762b5a0a9563acd9555eaa5e0b953a2
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 31876
-  timestamp: 1604249020971
-- platform: linux-64
+- kind: conda
   name: pyyaml
   version: 6.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - yaml >=0.2.5,<0.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
-  hash:
-    md5: bb010e368de4940771368bc3dc4c63e7
-    sha256: aa78ccddb0a75fa722f0f0eb3537c73ee1219c9dd46cea99d6b9eebfdd780f3d
-  build: py310h2372a71_1
-  arch: x86_64
-  subdir: linux-64
+  build: py39h0f82c59_1
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py39h0f82c59_1.conda
+  sha256: 96ef332c1199bed9779f6b5bf7671dd00654208a6fadb7b89d744e66286326dc
+  md5: b4f3bbf710410751f687ac04544c12b1
+  depends:
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
-  size: 170627
-  timestamp: 1695373587159
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/pyyaml
+  size: 159929
+  timestamp: 1695373838385
+- kind: conda
   name: pyyaml
   version: 6.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - yaml >=0.2.5,<0.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py310h2aa6e3c_1.conda
-  hash:
-    md5: 0e7ccdd121ce7b486f1de7917178387c
-    sha256: 7b8668cd86d2421c62ec241f840d84a600b854afc91383a509bbb60ba907aeec
-  build: py310h2aa6e3c_1
-  arch: aarch64
-  subdir: osx-arm64
+  build: py39hd1e30aa_1
   build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py39hd1e30aa_1.conda
+  sha256: 28b147c50ad48215f9427a52811848223ac0371be7caae88522e661a3bfb1448
+  md5: 37218233bcdc310e4fde6453bc1b40d8
+  depends:
+  - libgcc-ng >=12
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - yaml >=0.2.5,<0.3.0a0
   license: MIT
   license_family: MIT
-  size: 158641
-  timestamp: 1695373859696
-- platform: linux-64
-  name: qt-main
-  version: 5.15.8
-  category: main
-  manager: conda
-  dependencies:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.8,<1.2.9.0a0
-  - dbus >=1.13.6,<2.0a0
-  - expat >=2.5.0,<3.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gst-plugins-base >=1.22.0,<1.23.0a0
-  - gstreamer >=1.22.0,<1.23.0a0
-  - harfbuzz >=6.0.0,<7.0a0
-  - icu >=70.1,<71.0a0
-  - jpeg >=9e,<10a
-  - krb5 >=1.20.1,<1.21.0a0
-  - libclang >=15.0.7,<16.0a0
-  - libclang13 >=15.0.7
-  - libcups >=2.3.3,<2.4.0a0
-  - libevent >=2.1.10,<2.1.11.0a0
-  - libgcc-ng >=12
-  - libglib >=2.74.1,<3.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libpq >=15.1,<16.0a0
-  - libsqlite >=3.40.0,<4.0a0
-  - libstdcxx-ng >=12
-  - libxcb >=1.13,<1.14.0a0
-  - libxkbcommon >=1.0.3,<2.0a0
-  - libxml2 >=2.10.3,<2.11.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-libs >=8.0.32,<8.1.0a0
-  - nspr >=4.35,<5.0a0
-  - nss >=3.82,<4.0a0
-  - openssl >=3.0.8,<4.0a0
-  - pulseaudio >=16.1,<16.2.0a0
-  - xcb-util
-  - xcb-util-image
-  - xcb-util-keysyms
-  - xcb-util-renderutil
-  - xcb-util-wm
-  - zstd >=1.5.2,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h5d23da1_6.conda
-  hash:
-    md5: 59c73debd9405771690ddbbad6c57b69
-    sha256: fd0b6b8365fd4d0e86476a3047ba6a281eea0bdfef770df83b897fd73e959dd9
-  build: h5d23da1_6
-  arch: x86_64
-  subdir: linux-64
-  build_number: 6
-  constrains:
-  - qt 5.15.8
-  license: LGPL-3.0-only
-  license_family: LGPL
-  size: 52472654
-  timestamp: 1675839238854
-- platform: linux-64
-  name: rdma-core
-  version: '28.9'
-  category: main
-  manager: conda
-  dependencies:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-28.9-h59595ed_1.conda
-  hash:
-    md5: aeffb7c06b5f65e55e6c637408dc4100
-    sha256: 832f9393ab3144ce6468c6f150db9d398fad4451e96a8879afb3059f0c9902f6
-  build: h59595ed_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Linux-OpenIB
-  license_family: BSD
-  size: 3735644
-  timestamp: 1684785130341
-- platform: linux-64
-  name: re2
-  version: 2023.03.02
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.03.02-h8c504da_0.conda
-  hash:
-    md5: 206f8fa808748f6e90599c3368a1114e
-    sha256: 1727f893a352ca735fb96b09f9edf6fe18c409d65550fd37e8a192919e8c827b
-  build: h8c504da_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 201211
-  timestamp: 1677698930545
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/pyyaml
+  size: 178391
+  timestamp: 1695373606953
+- kind: conda
   name: re2
   version: 2023.06.02
-  category: main
-  manager: conda
-  dependencies:
-  - libre2-11 2023.06.02 h1753957_0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.06.02-h6135d0a_0.conda
-  hash:
-    md5: 8f23674174b155300696a2be8b5c1407
-    sha256: 963847258a82d9647311c5eb8829a49ac2161df12a304d5d6e61f788f0563442
   build: h6135d0a_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.06.02-h6135d0a_0.conda
+  sha256: 963847258a82d9647311c5eb8829a49ac2161df12a304d5d6e61f788f0563442
+  md5: 8f23674174b155300696a2be8b5c1407
+  depends:
+  - libre2-11 2023.06.02 h1753957_0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 27073
   timestamp: 1697065856329
-- platform: linux-64
+- kind: conda
+  name: re2
+  version: 2023.09.01
+  build: h7f4b329_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_1.conda
+  sha256: b8f9e366f02c559587327f0cd7fa45c5c399b4025f2c9e1aa292bb7cbe1482c0
+  md5: 30c0f66cbc5927a12662acf94067e780
+  depends:
+  - libre2-11 2023.09.01 h7a70373_1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26635
+  timestamp: 1708945310937
+- kind: conda
   name: readline
   version: '8.2'
-  category: main
-  manager: conda
-  dependencies:
+  build: h8228510_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+  sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
+  md5: 47d31b792659ce70f470b5c82fdfb7a4
+  depends:
   - libgcc-ng >=12
   - ncurses >=6.3,<7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-  hash:
-    md5: 47d31b792659ce70f470b5c82fdfb7a4
-    sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
-  build: h8228510_1
   arch: x86_64
-  subdir: linux-64
-  build_number: 1
+  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   size: 281456
   timestamp: 1679532220005
-- platform: osx-arm64
+- kind: conda
   name: readline
   version: '8.2'
-  category: main
-  manager: conda
-  dependencies:
-  - ncurses >=6.3,<7.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
-  hash:
-    md5: 8cbb776a2f641b943d413b3e19df71f4
-    sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
   build: h92ec313_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  arch: aarch64
+  platform: osx
   license: GPL-3.0-only
   license_family: GPL
   size: 250351
   timestamp: 1679532511311
-- platform: linux-64
+- kind: pypi
+  name: referencing
+  version: 0.35.1
+  url: https://files.pythonhosted.org/packages/b7/59/2056f61236782a2c86b33906c025d4f4a0b17be0161b63b70fd9e8775d36/referencing-0.35.1-py3-none-any.whl
+  sha256: eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de
+  requires_dist:
+  - attrs>=22.2.0
+  - rpds-py>=0.7.0
+  requires_python: '>=3.8'
+- kind: conda
   name: requests
   version: 2.31.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+  sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
+  md5: a30144e4156cdbb236f99ebb49828f8b
+  depends:
   - certifi >=2017.4.17
   - charset-normalizer >=2,<4
   - idna >=2.5,<4
   - python >=3.7
   - urllib3 >=1.21.1,<3
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a30144e4156cdbb236f99ebb49828f8b
-    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - chardet >=3.0.2,<6
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 56690
-  timestamp: 1684774408600
-- platform: osx-arm64
-  name: requests
-  version: 2.31.0
-  category: main
-  manager: conda
-  dependencies:
-  - certifi >=2017.4.17
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - python >=3.7
-  - urllib3 >=1.21.1,<3
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a30144e4156cdbb236f99ebb49828f8b
-    sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
-  build: pyhd8ed1ab_0
   arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  constrains:
-  - chardet >=3.0.2,<6
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
+  purls:
+  - pkg:pypi/requests
   size: 56690
   timestamp: 1684774408600
-- platform: linux-64
+- kind: conda
   name: requests-oauthlib
   version: 1.3.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.3.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 889e3c1b84467b64046776db95dc4c5ea4dad5afaa5ec18ad811bd95c63286b0
+  md5: 61b279f051eef9c89d58f4d813e75e04
+  depends:
   - oauthlib >=3.0.0
   - python >=3.4
   - requests >=2.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 61b279f051eef9c89d58f4d813e75e04
-    sha256: 889e3c1b84467b64046776db95dc4c5ea4dad5afaa5ec18ad811bd95c63286b0
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: ISC
-  noarch: python
+  purls:
+  - pkg:pypi/requests-oauthlib
   size: 22195
   timestamp: 1643557540321
-- platform: osx-arm64
-  name: requests-oauthlib
-  version: 1.3.1
-  category: main
-  manager: conda
-  dependencies:
-  - oauthlib >=3.0.0
-  - python >=3.4
-  - requests >=2.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.3.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 61b279f051eef9c89d58f4d813e75e04
-    sha256: 889e3c1b84467b64046776db95dc4c5ea4dad5afaa5ec18ad811bd95c63286b0
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: ISC
-  noarch: python
-  size: 22195
-  timestamp: 1643557540321
-- platform: linux-64
+- kind: pypi
   name: rerun-sdk
-  version: 0.10.1
-  category: main
-  manager: conda
-  dependencies:
-  - attrs >=23.1.0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - numpy >=1.23
-  - pillow
-  - pyarrow 10.0.1
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - typing_extensions >=4.5
-  url: https://conda.anaconda.org/conda-forge/linux-64/rerun-sdk-0.10.1-py310hc6cd4ac_0.conda
-  hash:
-    md5: e695d1a884862b1ee74ed5c3d832814f
-    sha256: 10362c42a368918783e688750f765abbfae6025ea2b3332ef18fd24fde994086
-  build: py310hc6cd4ac_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT OR Apache-2.0
-  size: 15309392
-  timestamp: 1698954100875
-- platform: osx-arm64
+  version: 0.16.0rc4
+  url: https://files.pythonhosted.org/packages/4e/65/181a8e55e867b5870d6f6b9217aabd93cdea77e2c8547873e98d154bb5c9/rerun_sdk-0.16.0rc4-cp38-abi3-macosx_11_0_arm64.whl
+  sha256: e17c113d83157f5f13e6ace7eec2e769643b758a986f3116158aa51661b66608
+  requires_dist:
+  - attrs>=23.1.0
+  - numpy>=1.23,<2
+  - pillow>=8.0.0
+  - pyarrow>=14.0.2
+  - typing-extensions>=4.5
+  - pytest==7.1.2 ; extra == 'tests'
+  requires_python: '>=3.8,<3.13'
+- kind: pypi
   name: rerun-sdk
-  version: 0.10.1
-  category: main
-  manager: conda
-  dependencies:
-  - __osx >=10.12
-  - __osx >=10.9
-  - attrs >=23.1.0
-  - libcxx >=16.0.6
-  - numpy >=1.23
-  - pillow
-  - pyarrow 10.0.1
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - typing_extensions >=4.5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rerun-sdk-0.10.1-py310hd5a4765_0.conda
-  hash:
-    md5: ced778da4552972c43ae6a41f54dc27c
-    sha256: dbbe344942afc9710c07e9e27280d6a934c7d04616615a92e755dc18ea2c9add
-  build: py310hd5a4765_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT OR Apache-2.0
-  size: 11695040
-  timestamp: 1698954646394
-- platform: linux-64
+  version: 0.16.0rc4
+  url: https://files.pythonhosted.org/packages/25/22/c6094d03eddbf051e8e2eb5621d062d90e1b3e9bd11284cf38dc0bb53c5e/rerun_sdk-0.16.0rc4-cp38-abi3-manylinux_2_31_x86_64.whl
+  sha256: 4fce057f3e5c4ad3e5b2fb81d5be85a4cb6cb13a0078adfc7130d49d6df6f33a
+  requires_dist:
+  - attrs>=23.1.0
+  - numpy>=1.23,<2
+  - pillow>=8.0.0
+  - pyarrow>=14.0.2
+  - typing-extensions>=4.5
+  - pytest==7.1.2 ; extra == 'tests'
+  requires_python: '>=3.8,<3.13'
+- kind: pypi
+  name: retrying
+  version: 1.3.4
+  url: https://files.pythonhosted.org/packages/8f/04/9e36f28be4c0532c0e9207ff9dc01fb13a2b0eb036476a213b0000837d0e/retrying-1.3.4-py3-none-any.whl
+  sha256: 8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35
+  requires_dist:
+  - six>=1.7.0
+- kind: pypi
+  name: rpds-py
+  version: 0.18.1
+  url: https://files.pythonhosted.org/packages/97/b1/12238bd8cdf3cef71e85188af133399bfde1bddf319007361cc869d6f6a7/rpds_py-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: e4c39ad2f512b4041343ea3c7894339e4ca7839ac38ca83d68a832fc8b3748ab
+  requires_python: '>=3.8'
+- kind: conda
   name: rsa
   version: '4.9'
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
+  sha256: 23214cdc15a41d14136754857fd9cd46ca3c55a7e751da3b3a48c673f0ee2a57
+  md5: 03bf410858b2cefc267316408a77c436
+  depends:
   - pyasn1 >=0.1.3
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 03bf410858b2cefc267316408a77c436
-    sha256: 23214cdc15a41d14136754857fd9cd46ca3c55a7e751da3b3a48c673f0ee2a57
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
+  purls:
+  - pkg:pypi/rsa
   size: 29863
   timestamp: 1658329024970
-- platform: osx-arm64
-  name: rsa
-  version: '4.9'
-  category: main
-  manager: conda
-  dependencies:
-  - pyasn1 >=0.1.3
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 03bf410858b2cefc267316408a77c436
-    sha256: 23214cdc15a41d14136754857fd9cd46ca3c55a7e751da3b3a48c673f0ee2a57
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 29863
-  timestamp: 1658329024970
-- platform: linux-64
-  name: s2n
-  version: 1.3.46
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - openssl >=3.1.1,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.3.46-h06160fa_0.conda
-  hash:
-    md5: 413d96a0b655c8f8aacc36473a2dbb04
-    sha256: 9e58ac9781b7e0c0b4a66da23d02889673b9b8b6db0ffef9ef4da003d83795a2
-  build: h06160fa_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 367038
-  timestamp: 1687686400683
-- platform: linux-64
+- kind: pypi
   name: safetensors
-  version: 0.3.3
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.3.3-py310hcb5633a_1.conda
-  hash:
-    md5: 7611b39e6ef1b8b073e73ce9e064377b
-    sha256: 94193b014a5ff85a81b50784f5c2d849bb0416ef19a98b7790b41bc27b2b19e3
-  build: py310hcb5633a_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1077683
-  timestamp: 1695444724866
-- platform: osx-arm64
+  version: 0.4.3
+  url: https://files.pythonhosted.org/packages/c2/2b/bdfdc24feb4cb02f49f55e9233253cd27d101215f81a248a7dbcfd590356/safetensors-0.4.3-cp39-cp39-macosx_11_0_arm64.whl
+  sha256: e375d975159ac534c7161269de24ddcd490df2157b55c1a6eeace6cbb56903f0
+  requires_dist:
+  - numpy>=1.21.6 ; extra == 'numpy'
+  - safetensors[numpy] ; extra == 'torch'
+  - torch>=1.10 ; extra == 'torch'
+  - safetensors[numpy] ; extra == 'tensorflow'
+  - tensorflow>=2.11.0 ; extra == 'tensorflow'
+  - safetensors[numpy] ; extra == 'pinned-tf'
+  - tensorflow==2.11.0 ; extra == 'pinned-tf'
+  - safetensors[numpy] ; extra == 'jax'
+  - flax>=0.6.3 ; extra == 'jax'
+  - jax>=0.3.25 ; extra == 'jax'
+  - jaxlib>=0.3.25 ; extra == 'jax'
+  - mlx>=0.0.9 ; extra == 'mlx'
+  - safetensors[numpy] ; extra == 'paddlepaddle'
+  - paddlepaddle>=2.4.1 ; extra == 'paddlepaddle'
+  - black==22.3 ; extra == 'quality'
+  - click==8.0.4 ; extra == 'quality'
+  - isort>=5.5.4 ; extra == 'quality'
+  - flake8>=3.8.3 ; extra == 'quality'
+  - safetensors[numpy] ; extra == 'testing'
+  - h5py>=3.7.0 ; extra == 'testing'
+  - huggingface-hub>=0.12.1 ; extra == 'testing'
+  - setuptools-rust>=1.5.2 ; extra == 'testing'
+  - pytest>=7.2.0 ; extra == 'testing'
+  - pytest-benchmark>=4.0.0 ; extra == 'testing'
+  - hypothesis>=6.70.2 ; extra == 'testing'
+  - safetensors[torch] ; extra == 'all'
+  - safetensors[numpy] ; extra == 'all'
+  - safetensors[pinned-tf] ; extra == 'all'
+  - safetensors[jax] ; extra == 'all'
+  - safetensors[paddlepaddle] ; extra == 'all'
+  - safetensors[quality] ; extra == 'all'
+  - safetensors[testing] ; extra == 'all'
+  - safetensors[all] ; extra == 'dev'
+  requires_python: '>=3.7'
+- kind: pypi
   name: safetensors
-  version: 0.3.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/safetensors-0.3.3-py310had9acf8_1.conda
-  hash:
-    md5: 68e60f55f34839231046cf5dfaec4504
-    sha256: 7b22ff8ed239cc04a175e6f639d6828a6e8fd8ddb9bb13706d025077c34fb722
-  build: py310had9acf8_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 359144
-  timestamp: 1695445194453
-- platform: linux-64
+  version: 0.4.3
+  url: https://files.pythonhosted.org/packages/38/7f/3ba803bd6d726d65e480bee2aaeea79580d2e4836e4c6ebc27144c62ce51/safetensors-0.4.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 01e4b22e3284cd866edeabe4f4d896229495da457229408d2e1e4810c5187121
+  requires_dist:
+  - numpy>=1.21.6 ; extra == 'numpy'
+  - safetensors[numpy] ; extra == 'torch'
+  - torch>=1.10 ; extra == 'torch'
+  - safetensors[numpy] ; extra == 'tensorflow'
+  - tensorflow>=2.11.0 ; extra == 'tensorflow'
+  - safetensors[numpy] ; extra == 'pinned-tf'
+  - tensorflow==2.11.0 ; extra == 'pinned-tf'
+  - safetensors[numpy] ; extra == 'jax'
+  - flax>=0.6.3 ; extra == 'jax'
+  - jax>=0.3.25 ; extra == 'jax'
+  - jaxlib>=0.3.25 ; extra == 'jax'
+  - mlx>=0.0.9 ; extra == 'mlx'
+  - safetensors[numpy] ; extra == 'paddlepaddle'
+  - paddlepaddle>=2.4.1 ; extra == 'paddlepaddle'
+  - black==22.3 ; extra == 'quality'
+  - click==8.0.4 ; extra == 'quality'
+  - isort>=5.5.4 ; extra == 'quality'
+  - flake8>=3.8.3 ; extra == 'quality'
+  - safetensors[numpy] ; extra == 'testing'
+  - h5py>=3.7.0 ; extra == 'testing'
+  - huggingface-hub>=0.12.1 ; extra == 'testing'
+  - setuptools-rust>=1.5.2 ; extra == 'testing'
+  - pytest>=7.2.0 ; extra == 'testing'
+  - pytest-benchmark>=4.0.0 ; extra == 'testing'
+  - hypothesis>=6.70.2 ; extra == 'testing'
+  - safetensors[torch] ; extra == 'all'
+  - safetensors[numpy] ; extra == 'all'
+  - safetensors[pinned-tf] ; extra == 'all'
+  - safetensors[jax] ; extra == 'all'
+  - safetensors[paddlepaddle] ; extra == 'all'
+  - safetensors[quality] ; extra == 'all'
+  - safetensors[testing] ; extra == 'all'
+  - safetensors[all] ; extra == 'dev'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: scikit-image
+  version: 0.22.0
+  url: https://files.pythonhosted.org/packages/65/c1/a49da20845f0f0e1afbb1c2586d406dc0acb84c26ae293bad6d7e7f718bc/scikit_image-0.22.0.tar.gz
+  sha256: 018d734df1d2da2719087d15f679d19285fce97cd37695103deadfaef2873236
+  requires_dist:
+  - numpy>=1.22
+  - scipy>=1.8
+  - networkx>=2.8
+  - pillow>=9.0.1
+  - imageio>=2.27
+  - tifffile>=2022.8.12
+  - packaging>=21
+  - lazy-loader>=0.3
+  - meson-python>=0.14 ; extra == 'build'
+  - wheel ; extra == 'build'
+  - setuptools>=67 ; extra == 'build'
+  - packaging>=21 ; extra == 'build'
+  - ninja ; extra == 'build'
+  - cython>=0.29.32 ; extra == 'build'
+  - pythran ; extra == 'build'
+  - numpy>=1.22 ; extra == 'build'
+  - spin==0.6 ; extra == 'build'
+  - build ; extra == 'build'
+  - pooch>=1.6.0 ; extra == 'data'
+  - pre-commit ; extra == 'developer'
+  - tomli ; python_version < '3.11' and extra == 'developer'
+  - sphinx>=7.2 ; extra == 'docs'
+  - sphinx-gallery>=0.14 ; extra == 'docs'
+  - numpydoc>=1.6 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - pytest-runner ; extra == 'docs'
+  - matplotlib>=3.5 ; extra == 'docs'
+  - dask[array]>=2022.9.2 ; extra == 'docs'
+  - pandas>=1.5 ; extra == 'docs'
+  - seaborn>=0.11 ; extra == 'docs'
+  - pooch>=1.6 ; extra == 'docs'
+  - tifffile>=2022.8.12 ; extra == 'docs'
+  - myst-parser ; extra == 'docs'
+  - ipywidgets ; extra == 'docs'
+  - ipykernel ; extra == 'docs'
+  - plotly>=5.10 ; extra == 'docs'
+  - kaleido ; extra == 'docs'
+  - scikit-learn>=1.1 ; extra == 'docs'
+  - sphinx-design>=0.5 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.14.1 ; extra == 'docs'
+  - pywavelets>=1.1.1 ; extra == 'docs'
+  - simpleitk ; extra == 'optional'
+  - astropy>=5.0 ; extra == 'optional'
+  - cloudpickle>=0.2.1 ; extra == 'optional'
+  - dask[array]>=2021.1.0 ; extra == 'optional'
+  - matplotlib>=3.5 ; extra == 'optional'
+  - pooch>=1.6.0 ; extra == 'optional'
+  - pyamg ; extra == 'optional'
+  - pywavelets>=1.1.1 ; extra == 'optional'
+  - scikit-learn>=1.1 ; extra == 'optional'
+  - asv ; extra == 'test'
+  - matplotlib>=3.5 ; extra == 'test'
+  - numpydoc>=1.5 ; extra == 'test'
+  - pooch>=1.6.0 ; extra == 'test'
+  - pytest>=7.0 ; extra == 'test'
+  - pytest-cov>=2.11.0 ; extra == 'test'
+  - pytest-localserver ; extra == 'test'
+  - pytest-faulthandler ; extra == 'test'
+  requires_python: '>=3.9'
+- kind: pypi
+  name: scikit-image
+  version: 0.22.0
+  url: https://files.pythonhosted.org/packages/a3/7e/4cd853a855ac34b4ef3ef6a5c3d1c2e96eaca1154fc6be75db55ffa87393/scikit_image-0.22.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 3b7a6c89e8d6252332121b58f50e1625c35f7d6a85489c0b6b7ee4f5155d547a
+  requires_dist:
+  - numpy>=1.22
+  - scipy>=1.8
+  - networkx>=2.8
+  - pillow>=9.0.1
+  - imageio>=2.27
+  - tifffile>=2022.8.12
+  - packaging>=21
+  - lazy-loader>=0.3
+  - meson-python>=0.14 ; extra == 'build'
+  - wheel ; extra == 'build'
+  - setuptools>=67 ; extra == 'build'
+  - packaging>=21 ; extra == 'build'
+  - ninja ; extra == 'build'
+  - cython>=0.29.32 ; extra == 'build'
+  - pythran ; extra == 'build'
+  - numpy>=1.22 ; extra == 'build'
+  - spin==0.6 ; extra == 'build'
+  - build ; extra == 'build'
+  - pooch>=1.6.0 ; extra == 'data'
+  - pre-commit ; extra == 'developer'
+  - tomli ; python_version < '3.11' and extra == 'developer'
+  - sphinx>=7.2 ; extra == 'docs'
+  - sphinx-gallery>=0.14 ; extra == 'docs'
+  - numpydoc>=1.6 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - pytest-runner ; extra == 'docs'
+  - matplotlib>=3.5 ; extra == 'docs'
+  - dask[array]>=2022.9.2 ; extra == 'docs'
+  - pandas>=1.5 ; extra == 'docs'
+  - seaborn>=0.11 ; extra == 'docs'
+  - pooch>=1.6 ; extra == 'docs'
+  - tifffile>=2022.8.12 ; extra == 'docs'
+  - myst-parser ; extra == 'docs'
+  - ipywidgets ; extra == 'docs'
+  - ipykernel ; extra == 'docs'
+  - plotly>=5.10 ; extra == 'docs'
+  - kaleido ; extra == 'docs'
+  - scikit-learn>=1.1 ; extra == 'docs'
+  - sphinx-design>=0.5 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.14.1 ; extra == 'docs'
+  - pywavelets>=1.1.1 ; extra == 'docs'
+  - simpleitk ; extra == 'optional'
+  - astropy>=5.0 ; extra == 'optional'
+  - cloudpickle>=0.2.1 ; extra == 'optional'
+  - dask[array]>=2021.1.0 ; extra == 'optional'
+  - matplotlib>=3.5 ; extra == 'optional'
+  - pooch>=1.6.0 ; extra == 'optional'
+  - pyamg ; extra == 'optional'
+  - pywavelets>=1.1.1 ; extra == 'optional'
+  - scikit-learn>=1.1 ; extra == 'optional'
+  - asv ; extra == 'test'
+  - matplotlib>=3.5 ; extra == 'test'
+  - numpydoc>=1.5 ; extra == 'test'
+  - pooch>=1.6.0 ; extra == 'test'
+  - pytest>=7.0 ; extra == 'test'
+  - pytest-cov>=2.11.0 ; extra == 'test'
+  - pytest-localserver ; extra == 'test'
+  - pytest-faulthandler ; extra == 'test'
+  requires_python: '>=3.9'
+- kind: pypi
+  name: scikit-learn
+  version: 1.4.2
+  url: https://files.pythonhosted.org/packages/82/40/5906b7ae6e303ece856a4262b0e7a963eb0187c167b539ff87bc1fe8f887/scikit_learn-1.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 49d64ef6cb8c093d883e5a36c4766548d974898d378e395ba41a806d0e824db8
+  requires_dist:
+  - numpy>=1.19.5
+  - scipy>=1.6.0
+  - joblib>=1.2.0
+  - threadpoolctl>=2.0.0
+  - matplotlib>=3.3.4 ; extra == 'benchmark'
+  - pandas>=1.1.5 ; extra == 'benchmark'
+  - memory-profiler>=0.57.0 ; extra == 'benchmark'
+  - matplotlib>=3.3.4 ; extra == 'docs'
+  - scikit-image>=0.17.2 ; extra == 'docs'
+  - pandas>=1.1.5 ; extra == 'docs'
+  - seaborn>=0.9.0 ; extra == 'docs'
+  - memory-profiler>=0.57.0 ; extra == 'docs'
+  - sphinx>=6.0.0 ; extra == 'docs'
+  - sphinx-copybutton>=0.5.2 ; extra == 'docs'
+  - sphinx-gallery>=0.15.0 ; extra == 'docs'
+  - numpydoc>=1.2.0 ; extra == 'docs'
+  - pillow>=7.1.2 ; extra == 'docs'
+  - pooch>=1.6.0 ; extra == 'docs'
+  - sphinx-prompt>=1.3.0 ; extra == 'docs'
+  - sphinxext-opengraph>=0.4.2 ; extra == 'docs'
+  - plotly>=5.14.0 ; extra == 'docs'
+  - matplotlib>=3.3.4 ; extra == 'examples'
+  - scikit-image>=0.17.2 ; extra == 'examples'
+  - pandas>=1.1.5 ; extra == 'examples'
+  - seaborn>=0.9.0 ; extra == 'examples'
+  - pooch>=1.6.0 ; extra == 'examples'
+  - plotly>=5.14.0 ; extra == 'examples'
+  - matplotlib>=3.3.4 ; extra == 'tests'
+  - scikit-image>=0.17.2 ; extra == 'tests'
+  - pandas>=1.1.5 ; extra == 'tests'
+  - pytest>=7.1.2 ; extra == 'tests'
+  - pytest-cov>=2.9.0 ; extra == 'tests'
+  - ruff>=0.0.272 ; extra == 'tests'
+  - black>=23.3.0 ; extra == 'tests'
+  - mypy>=1.3 ; extra == 'tests'
+  - pyamg>=4.0.0 ; extra == 'tests'
+  - polars>=0.19.12 ; extra == 'tests'
+  - pyarrow>=12.0.0 ; extra == 'tests'
+  - numpydoc>=1.2.0 ; extra == 'tests'
+  - pooch>=1.6.0 ; extra == 'tests'
+  requires_python: '>=3.9'
+- kind: conda
   name: scipy
   version: 1.11.4
-  category: main
-  manager: conda
-  dependencies:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  - numpy >=1.22.4,<1.28
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.4-py310hb13e2d6_0.conda
-  hash:
-    md5: f0063b2885bfae11324a00a693f88781
-    sha256: d465ffa50c22c0ce7472831abbb01f10411bb62d2ee3b493ff3fe3dc214765cb
-  build: py310hb13e2d6_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 15254417
-  timestamp: 1700813355821
-- platform: osx-arm64
-  name: scipy
-  version: 1.11.4
-  category: main
-  manager: conda
-  dependencies:
+  build: py39h36c428d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.4-py39h36c428d_0.conda
+  sha256: 960a1a8225fdd52442cd3740f8bd40057caee527ba49de2991760843afe71bba
+  md5: 5a7b8c8fdec2c065b32dbd0e1b3b41ee
+  depends:
   - __osx >=10.9
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -8918,211 +5732,159 @@ package:
   - liblapack >=3.9.0,<4.0a0
   - numpy >=1.22.4,<1.28
   - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.4-py310h2b794db_0.conda
-  hash:
-    md5: 63565e585933d2853fa3c33d2e4c1007
-    sha256: bf95a330f5568456378ba51311b859db04e1f0e2b61970d69aad9eea8ee88d8b
-  build: py310h2b794db_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - libopenblas <0.3.26
   license: BSD-3-Clause
   license_family: BSD
-  size: 13965072
-  timestamp: 1700814632317
-- platform: linux-64
+  purls:
+  - pkg:pypi/scipy
+  size: 14026964
+  timestamp: 1700814635700
+- kind: conda
+  name: scipy
+  version: 1.11.4
+  build: py39h474f0d3_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.4-py39h474f0d3_0.conda
+  sha256: c3f0c06d2285b249a26a050e0464957eeb7e6b1fac93e3acd4218123fd1047db
+  md5: 4b401c1516417b4b14aa1249d2f7929d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - numpy >=1.22.4,<1.28
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - libopenblas <0.3.26
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy
+  size: 14902947
+  timestamp: 1700813355191
+- kind: conda
   name: setuptools
   version: 68.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc2166155db840c634a1291a5c35a709
-    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+  sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  md5: fc2166155db840c634a1291a5c35a709
+  depends:
+  - python >=3.7
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/setuptools
   size: 464399
   timestamp: 1694548452441
-- platform: osx-arm64
-  name: setuptools
-  version: 68.2.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc2166155db840c634a1291a5c35a709
-    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 464399
-  timestamp: 1694548452441
-- platform: linux-64
-  name: sip
-  version: 6.7.12
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - packaging
-  - ply
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tomli
-  url: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py310hc6cd4ac_0.conda
-  hash:
-    md5: 68d5bfccaba2d89a7812098dd3966d9b
-    sha256: 4c350a7ed9f5fd98196a50bc74ce1dc3bb05b0c90d17ea120439755fe2075796
-  build: py310hc6cd4ac_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 494293
-  timestamp: 1697300616950
-- platform: linux-64
+- kind: conda
   name: six
   version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: e5f25f8dbc060e9a8d912e432202afc2
-    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
   build: pyh6c4a22f_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
+  sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+  md5: e5f25f8dbc060e9a8d912e432202afc2
+  depends:
+  - python
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/six
   size: 14259
   timestamp: 1620240338595
-- platform: osx-arm64
-  name: six
-  version: 1.16.0
-  category: main
-  manager: conda
-  dependencies:
-  - python
-  url: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-  hash:
-    md5: e5f25f8dbc060e9a8d912e432202afc2
-    sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-  build: pyh6c4a22f_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 14259
-  timestamp: 1620240338595
-- platform: linux-64
-  name: snappy
-  version: 1.1.10
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
-  hash:
-    md5: e6d228cd0bb74a51dd18f5bfce0b4115
-    sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
-  build: h9fff704_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38865
-  timestamp: 1678534590321
-- platform: osx-arm64
-  name: snappy
-  version: 1.1.10
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=14.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
-  hash:
-    md5: ac82a611d1a67a598096ebaa857198e3
-    sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
-  build: h17c5cce_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 33879
-  timestamp: 1678534968831
-- platform: osx-arm64
+- kind: pypi
+  name: soupsieve
+  version: '2.5'
+  url: https://files.pythonhosted.org/packages/4c/f3/038b302fdfbe3be7da016777069f26ceefe11a681055ea1f7817546508e3/soupsieve-2.5-py3-none-any.whl
+  sha256: eaa337ff55a1579b6549dc679565eac1e3d000563bcb1c8ab0d0fefbc0c2cdc7
+  requires_python: '>=3.8'
+- kind: pypi
+  name: stack-data
+  version: 0.6.3
+  url: https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl
+  sha256: d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695
+  requires_dist:
+  - executing>=1.2.0
+  - asttokens>=2.1.0
+  - pure-eval
+  - pytest ; extra == 'tests'
+  - typeguard ; extra == 'tests'
+  - pygments ; extra == 'tests'
+  - littleutils ; extra == 'tests'
+  - cython ; extra == 'tests'
+- kind: conda
   name: svt-av1
   version: 1.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=14.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.4.1-h7ea286d_0.conda
-  hash:
-    md5: c249fb2d81c39843166f20b6a69a99c3
-    sha256: b868a00e01cf9a5f5f411fc3e82500a22a910e3c916d06d9c443b2cc96aa93c4
   build: h7ea286d_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.4.1-h7ea286d_0.conda
+  sha256: b868a00e01cf9a5f5f411fc3e82500a22a910e3c916d06d9c443b2cc96aa93c4
+  md5: c249fb2d81c39843166f20b6a69a99c3
+  depends:
+  - libcxx >=14.0.6
+  arch: aarch64
+  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 1187163
   timestamp: 1670989108960
-- platform: linux-64
+- kind: conda
   name: tbb
   version: 2021.9.0
-  category: main
-  manager: conda
-  dependencies:
+  build: hf52228f_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.9.0-hf52228f_0.conda
+  sha256: 86352f4361e8dc2374a95d9d1dfee742beecaa59dcb0e76ca36ca06a4efe1df2
+  md5: f495e42d3d2020b025705625edf35490
+  depends:
   - libgcc-ng >=12
   - libhwloc >=2.9.1,<2.9.2.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.9.0-hf52228f_0.conda
-  hash:
-    md5: f495e42d3d2020b025705625edf35490
-    sha256: 86352f4361e8dc2374a95d9d1dfee742beecaa59dcb0e76ca36ca06a4efe1df2
-  build: hf52228f_0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  platform: linux
   license: Apache-2.0
   license_family: APACHE
   size: 1527865
   timestamp: 1681486787952
-- platform: linux-64
+- kind: pypi
+  name: tenacity
+  version: 8.3.0
+  url: https://files.pythonhosted.org/packages/61/a1/6bb0cbebefb23641f068bb58a2bc56da9beb2b1c550242e3c540b37698f3/tenacity-8.3.0-py3-none-any.whl
+  sha256: 3649f6443dbc0d9b01b9d8020a9c4ec7a1ff5f6f3c6c8a036ef371f573fe9185
+  requires_dist:
+  - reno ; extra == 'doc'
+  - sphinx ; extra == 'doc'
+  - pytest ; extra == 'test'
+  - tornado>=4.5 ; extra == 'test'
+  - typeguard ; extra == 'test'
+  requires_python: '>=3.8'
+- kind: conda
   name: tensorboard
   version: 2.15.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tensorboard-2.15.1-pyhd8ed1ab_0.conda
+  sha256: 652c97025f21fdb6473ccaa5b2c53ca8ae816d550a596a4544566cfcf5273591
+  md5: 0bba0cc8e5247bca0411ee63e9b0bb2f
+  depends:
   - absl-py >=0.4
   - google-auth >=1.6.3,<3
   - google-auth-oauthlib >=0.5,<2
@@ -9136,1497 +5898,674 @@ package:
   - six >=1.9
   - tensorboard-data-server >=0.7.0,<0.8.0
   - werkzeug >=1.0.1
-  url: https://conda.anaconda.org/conda-forge/noarch/tensorboard-2.15.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0bba0cc8e5247bca0411ee63e9b0bb2f
-    sha256: 652c97025f21fdb6473ccaa5b2c53ca8ae816d550a596a4544566cfcf5273591
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
+  purls:
+  - pkg:pypi/tensorboard
   size: 5205238
   timestamp: 1699025407393
-- platform: osx-arm64
-  name: tensorboard
-  version: 2.15.1
-  category: main
-  manager: conda
-  dependencies:
-  - absl-py >=0.4
-  - google-auth >=1.6.3,<3
-  - google-auth-oauthlib >=0.5,<2
-  - grpcio >=1.48.2
-  - markdown >=2.6.8
-  - numpy >=1.12.0
-  - protobuf >=3.19.6
-  - python >=3.8
-  - requests >=2.21.0,<3
-  - setuptools >=41.0.0
-  - six >=1.9
-  - tensorboard-data-server >=0.7.0,<0.8.0
-  - werkzeug >=1.0.1
-  url: https://conda.anaconda.org/conda-forge/noarch/tensorboard-2.15.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0bba0cc8e5247bca0411ee63e9b0bb2f
-    sha256: 652c97025f21fdb6473ccaa5b2c53ca8ae816d550a596a4544566cfcf5273591
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 5205238
-  timestamp: 1699025407393
-- platform: linux-64
+- kind: conda
   name: tensorboard-data-server
   version: 0.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - openssl >=3.1.3,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/tensorboard-data-server-0.7.0-py310h75e40e8_1.conda
-  hash:
-    md5: e562478facfa960813945204273ecac5
-    sha256: 3a951b6fe064affc135c6cd2554853b2c1290ffc987fe945ce2af4b1a70e52dc
-  build: py310h75e40e8_1
-  arch: x86_64
-  subdir: linux-64
+  build: py39had97604_1
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tensorboard-data-server-0.7.0-py39had97604_1.conda
+  sha256: dc9b5fc5f5b1cbea2544a73b5e578c200210438fd5cb669c6dfd64e21c9e3c7f
+  md5: dacefd6d65ec1e5aac14d2607aba59ed
+  depends:
+  - openssl >=3.1.3,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
   license: Apache-2.0
   license_family: APACHE
-  size: 4764067
-  timestamp: 1695425891393
-- platform: osx-arm64
+  purls:
+  - pkg:pypi/tensorboard-data-server
+  size: 3485331
+  timestamp: 1695426462480
+- kind: conda
   name: tensorboard-data-server
   version: 0.7.0
-  category: main
-  manager: conda
-  dependencies:
-  - openssl >=3.1.3,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tensorboard-data-server-0.7.0-py310hdd3b5e7_1.conda
-  hash:
-    md5: 1bb33b5eff02853dc8b6c1459f73038f
-    sha256: e04e5343256159b942b25942d942cce2affc2c8bb6bd07060ba1ac8c8b856fdb
-  build: py310hdd3b5e7_1
-  arch: aarch64
-  subdir: osx-arm64
+  build: py39hd4f0224_1
   build_number: 1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3486353
-  timestamp: 1695426470890
-- platform: linux-64
-  name: timm
-  version: 0.9.12
-  category: main
-  manager: conda
-  dependencies:
-  - huggingface_hub
-  - python >=3.7
-  - pytorch >=1.7
-  - pyyaml
-  - safetensors
-  - torchvision
-  url: https://conda.anaconda.org/conda-forge/noarch/timm-0.9.12-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7d2b63ea3b1cf09129f6e2c065337069
-    sha256: 5708dd5718c0214a6d4eb00d216f79089a934c7cfa3700957c4049e0b152145a
-  build: pyhd8ed1ab_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 1372168
-  timestamp: 1700926877538
-- platform: osx-arm64
-  name: timm
-  version: 0.9.12
-  category: main
-  manager: conda
-  dependencies:
-  - huggingface_hub
-  - python >=3.7
-  - pytorch >=1.7
-  - pyyaml
-  - safetensors
-  - torchvision
-  url: https://conda.anaconda.org/conda-forge/noarch/timm-0.9.12-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7d2b63ea3b1cf09129f6e2c065337069
-    sha256: 5708dd5718c0214a6d4eb00d216f79089a934c7cfa3700957c4049e0b152145a
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 1372168
-  timestamp: 1700926877538
-- platform: linux-64
-  name: tk
-  version: 8.6.13
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/linux-64/tensorboard-data-server-0.7.0-py39hd4f0224_1.conda
+  sha256: 0389876d33062d7859a8078e6658569ea5df7a06206852c8dd02314e0db170b5
+  md5: 385936ccbb943d2be60177871c1c0bb5
+  depends:
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
-  hash:
-    md5: d453b98d9c83e71da0741bb0ff4d76bc
-    sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
-  build: noxft_h4845f30_101
-  arch: x86_64
-  subdir: linux-64
-  build_number: 101
-  license: TCL
-  license_family: BSD
-  size: 3318875
-  timestamp: 1699202167581
-- platform: osx-arm64
+  - openssl >=3.1.3,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/tensorboard-data-server
+  size: 4768532
+  timestamp: 1695425733459
+- kind: pypi
+  name: threadpoolctl
+  version: 3.5.0
+  url: https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl
+  sha256: 56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467
+  requires_python: '>=3.8'
+- kind: pypi
+  name: tifffile
+  version: 2024.5.10
+  url: https://files.pythonhosted.org/packages/c1/79/29d0fa40017f7b749ce344759dcc21e2ec9bbb81fc69ca2ce06e261f83f0/tifffile-2024.5.10-py3-none-any.whl
+  sha256: 4154f091aa24d4e75bfad9ab2d5424a68c70e67b8220188066dc61946d4551bd
+  requires_dist:
+  - numpy
+  - imagecodecs>=2023.8.12 ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - defusedxml ; extra == 'all'
+  - lxml ; extra == 'all'
+  - zarr ; extra == 'all'
+  - fsspec ; extra == 'all'
+  requires_python: '>=3.9'
+- kind: pypi
+  name: timm
+  version: 1.0.3
+  url: https://files.pythonhosted.org/packages/19/0d/57fe21d3bcba4832ed59bc3bf0f544e8f0011f8ccd6fd85bc8e2a5d42c94/timm-1.0.3-py3-none-any.whl
+  sha256: d1ec86f7765aa79fbc7491508fa6e285d38a38f10bf4fe44ba2e9c70f91f0f5b
+  requires_dist:
+  - torch
+  - torchvision
+  - pyyaml
+  - huggingface-hub
+  - safetensors
+  requires_python: '>=3.8'
+- kind: conda
   name: tk
   version: 8.6.13
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
-  hash:
-    md5: b50a57ba89c32b62428b71a875291c9b
-    sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
   build: h5083fa2_1
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
   license: TCL
   license_family: BSD
   size: 3145523
   timestamp: 1699202432999
-- platform: linux-64
-  name: toml
-  version: 0.10.2
-  category: main
-  manager: conda
-  dependencies:
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: f832c45a477c78bebd107098db465095
-    sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
-  build: pyhd8ed1ab_0
-  arch: x86_64
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: noxft_h4845f30_101
+  build_number: 101
   subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 18433
-  timestamp: 1604308660817
-- platform: linux-64
-  name: tomli
-  version: 2.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 5844808ffab9ebdb694585b50ba02a96
-    sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  build: pyhd8ed1ab_0
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+  sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
+  md5: d453b98d9c83e71da0741bb0ff4d76bc
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 15940
-  timestamp: 1644342331069
-- platform: linux-64
+  platform: linux
+  license: TCL
+  license_family: BSD
+  size: 3318875
+  timestamp: 1699202167581
+- kind: conda
   name: torchmetrics
   version: 1.2.1
-  category: main
-  manager: conda
-  dependencies:
-  - lightning-utilities >=0.8.0
-  - numpy >1.20.0
-  - packaging >17.1
-  - python >=3.7
-  - pytorch >=1.8.1
-  - setuptools
-  url: https://conda.anaconda.org/conda-forge/noarch/torchmetrics-1.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: f6468e9ea893241ad7b8eae519f7e3a5
-    sha256: 26abe526d9514f096f196628ede28fb10d8e65cc19350b3be19f7bc465a22cec
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: APACHE
-  noarch: python
-  size: 327227
-  timestamp: 1701463071867
-- platform: osx-arm64
-  name: torchmetrics
-  version: 1.2.1
-  category: main
-  manager: conda
-  dependencies:
-  - lightning-utilities >=0.8.0
-  - numpy >1.20.0
-  - packaging >17.1
-  - python >=3.7
-  - pytorch >=1.8.1
-  - setuptools
-  url: https://conda.anaconda.org/conda-forge/noarch/torchmetrics-1.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: f6468e9ea893241ad7b8eae519f7e3a5
-    sha256: 26abe526d9514f096f196628ede28fb10d8e65cc19350b3be19f7bc465a22cec
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/torchmetrics-1.2.1-pyhd8ed1ab_0.conda
+  sha256: 26abe526d9514f096f196628ede28fb10d8e65cc19350b3be19f7bc465a22cec
+  md5: f6468e9ea893241ad7b8eae519f7e3a5
+  depends:
+  - lightning-utilities >=0.8.0
+  - numpy >1.20.0
+  - packaging >17.1
+  - python >=3.7
+  - pytorch >=1.8.1
+  - setuptools
+  arch: aarch64
+  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  noarch: python
+  purls:
+  - pkg:pypi/torchmetrics
   size: 327227
   timestamp: 1701463071867
-- platform: linux-64
+- kind: conda
   name: torchvision
   version: 0.14.1
-  category: main
-  manager: conda
-  dependencies:
+  build: py39_cpu
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/pytorch/osx-arm64/torchvision-0.14.1-py39_cpu.tar.bz2
+  sha256: 864a306443cb6da9ac6dffbde6839e60b42ecbd284c17eee00a793ebce4f6f94
+  md5: 6ad912a9eeb6c714e4d5f984892cf99e
+  depends:
   - ffmpeg >=4.2
   - jpeg
   - libpng
   - numpy >=1.11
   - pillow >=5.3.0,!=8.3.*
-  - python >=3.10,<3.11.0a0
+  - python >=3.9,<3.10.0a0
+  - pytorch 1.13.1
+  - requests
+  constrains:
+  - cpuonly
+  license: BSD
+  purls:
+  - pkg:pypi/torchvision
+  size: 6426072
+  timestamp: 1670598063762
+- kind: conda
+  name: torchvision
+  version: 0.14.1
+  build: py39_cu117
+  subdir: linux-64
+  url: https://conda.anaconda.org/pytorch/linux-64/torchvision-0.14.1-py39_cu117.tar.bz2
+  sha256: 3c995765c6ec5909dbf4a35de58b35cb481bfeb97b09b2bd931d3a1d9fced7ae
+  md5: ec0dad2404c541586f972e5207727829
+  depends:
+  - ffmpeg >=4.2
+  - jpeg
+  - libpng
+  - numpy >=1.11
+  - pillow >=5.3.0,!=8.3.*
+  - python >=3.9,<3.10.0a0
   - pytorch 1.13.1
   - pytorch-cuda 11.7.*
   - pytorch-mutex 1.0 cuda
   - requests
-  url: https://conda.anaconda.org/pytorch/linux-64/torchvision-0.14.1-py310_cu117.tar.bz2
-  hash:
-    md5: d2aead3dc1b8facab1c62a61f2ec8f1e
-    sha256: 329b3e42c47b796f35ee1498d7da4ee1426e83d5fe9430f0772f9c15564e0c74
-  build: py310_cu117
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
   constrains:
   - cpuonly <0
   license: BSD
-  size: 8149353
-  timestamp: 1670555049297
-- platform: osx-arm64
-  name: torchvision
-  version: 0.14.1
-  category: main
-  manager: conda
-  dependencies:
-  - ffmpeg >=4.2
-  - jpeg
-  - libpng
-  - numpy >=1.11
-  - pillow >=5.3.0,!=8.3.*
-  - python >=3.10,<3.11.0a0
-  - pytorch 1.13.1
-  - requests
-  url: https://conda.anaconda.org/pytorch/osx-arm64/torchvision-0.14.1-py310_cpu.tar.bz2
-  hash:
-    md5: 0861c91072a2192e322a431e22703f89
-    sha256: 9ff11220360cacae90cc980f750ca4eefd282d677ff21d507a582c85cc5fc1f6
-  build: py310_cpu
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  constrains:
-  - cpuonly
-  license: BSD
-  size: 6450491
-  timestamp: 1670598065321
-- platform: linux-64
-  name: tornado
-  version: 6.3.3
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py310h2372a71_1.conda
-  hash:
-    md5: b23e0147fa5f7a9380e06334c7266ad5
-    sha256: 209b6788b81739d3cdc2f04ad3f6f323efd85b1a30f2edce98ab76d98079fac8
-  build: py310h2372a71_1
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1
-  license: Apache-2.0
-  license_family: Apache
-  size: 641597
-  timestamp: 1695373710038
-- platform: osx-arm64
-  name: tornado
-  version: 6.3.3
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.3-py310h2aa6e3c_1.conda
-  hash:
-    md5: 8e480fb72ff6963b2a1ceb2f2ede62cf
-    sha256: 476ccfdc55e8eff548938b19cea93c5292770f8219d9b6d4f05f665ed60bc061
-  build: py310h2aa6e3c_1
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 1
-  license: Apache-2.0
-  license_family: Apache
-  size: 641741
-  timestamp: 1695374073257
-- platform: linux-64
+  purls:
+  - pkg:pypi/torchvision
+  size: 7959109
+  timestamp: 1670555029745
+- kind: conda
   name: tqdm
   version: 4.66.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
+  sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
+  md5: 03c97908b976498dcae97eb4e4f3149c
+  depends:
   - colorama
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 03c97908b976498dcae97eb4e4f3149c
-    sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: MPL-2.0 or MIT
-  noarch: python
+  purls:
+  - pkg:pypi/tqdm
   size: 89449
   timestamp: 1691671387674
-- platform: osx-arm64
-  name: tqdm
-  version: 4.66.1
-  category: main
-  manager: conda
-  dependencies:
-  - colorama
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 03c97908b976498dcae97eb4e4f3149c
-    sha256: b61c9222af05e8c5ff27e4a4d2eb81870c21ffd7478346be3ef644b7a3759cc4
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MPL-2.0 or MIT
-  noarch: python
-  size: 89449
-  timestamp: 1691671387674
-- platform: linux-64
+- kind: pypi
+  name: traitlets
+  version: 5.14.3
+  url: https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl
+  sha256: b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f
+  requires_dist:
+  - myst-parser ; extra == 'docs'
+  - pydata-sphinx-theme ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - argcomplete>=3.0.3 ; extra == 'test'
+  - mypy>=1.7.0 ; extra == 'test'
+  - pre-commit ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - pytest-mypy-testing ; extra == 'test'
+  - pytest<8.2,>=7.0 ; extra == 'test'
+  requires_python: '>=3.8'
+- kind: pypi
   name: transforms3d
   version: 0.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - numpy >=1.15
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/transforms3d-0.4.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 095d4a3d0f1fe80eb5078c5373aaf8f4
-    sha256: ba4dae71469da18db8fa7824f7217438a7433b2249e6a37a41d1150a017ebd22
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 2702952
-  timestamp: 1662101648442
-- platform: osx-arm64
-  name: transforms3d
-  version: 0.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - numpy >=1.15
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/transforms3d-0.4.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 095d4a3d0f1fe80eb5078c5373aaf8f4
-    sha256: ba4dae71469da18db8fa7824f7217438a7433b2249e6a37a41d1150a017ebd22
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-2-Clause
-  license_family: BSD
-  noarch: python
-  size: 2702952
-  timestamp: 1662101648442
-- platform: linux-64
+  url: https://files.pythonhosted.org/packages/56/94/65e0fe886c6d5c86f4a0552dc98f49f9ed9d77c4d925a0af97d48a8226de/transforms3d-0.4.1-py3-none-any.whl
+  sha256: aea08776c1c915c8b424418994202aced8e46301c375ce63423d14f1d0045aa7
+  requires_python: '>=3.6'
+- kind: pypi
   name: trimesh
-  version: 4.0.5
-  category: main
-  manager: conda
-  dependencies:
-  - numpy
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.0.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5615d308618330b131013a543a671fd5
-    sha256: 9e640cfa56182b2c2661316006c3d109ba1f6a7b7f14e14ad3f2dbec96266195
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  constrains:
-  - networkx
-  - svg.path
-  - meshio
-  - xxhash
-  - pycollada
-  - pyglet
-  - jsonschema
-  - pillow
-  - shapely
-  - lxml
-  - chardet
-  - sympy
-  - scikit-image
-  - mapbox_earcut
-  - rtree
-  - psutil
-  - setuptools
-  - msgpack-python
-  - colorlog
-  - requests
-  - scipy
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 557704
-  timestamp: 1700709104390
-- platform: osx-arm64
-  name: trimesh
-  version: 4.0.5
-  category: main
-  manager: conda
-  dependencies:
-  - numpy
-  - python >=2.7
-  url: https://conda.anaconda.org/conda-forge/noarch/trimesh-4.0.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5615d308618330b131013a543a671fd5
-    sha256: 9e640cfa56182b2c2661316006c3d109ba1f6a7b7f14e14ad3f2dbec96266195
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  constrains:
-  - networkx
-  - svg.path
-  - meshio
-  - xxhash
-  - pycollada
-  - pyglet
-  - jsonschema
-  - pillow
-  - shapely
-  - lxml
-  - chardet
-  - sympy
-  - scikit-image
-  - mapbox_earcut
-  - rtree
-  - psutil
-  - setuptools
-  - msgpack-python
-  - colorlog
-  - requests
-  - scipy
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 557704
-  timestamp: 1700709104390
-- platform: linux-64
+  version: 4.3.2
+  url: https://files.pythonhosted.org/packages/57/7b/557a411622ff3e144d52bebbf8ad8a28bb18ee55ff68e1eb5ebfce755975/trimesh-4.3.2-py3-none-any.whl
+  sha256: 7563182a9379485b88a44e87156fe54b41fb6f8f030001b9b6de39abdef05c22
+  requires_dist:
+  - numpy>=1.20
+  - trimesh[easy,recommend,test] ; extra == 'all'
+  - colorlog ; extra == 'easy'
+  - mapbox-earcut ; extra == 'easy'
+  - chardet ; extra == 'easy'
+  - lxml ; extra == 'easy'
+  - jsonschema ; extra == 'easy'
+  - networkx ; extra == 'easy'
+  - svg-path ; extra == 'easy'
+  - pycollada ; extra == 'easy'
+  - setuptools ; extra == 'easy'
+  - shapely ; extra == 'easy'
+  - xxhash ; extra == 'easy'
+  - rtree ; extra == 'easy'
+  - httpx ; extra == 'easy'
+  - scipy ; extra == 'easy'
+  - embreex ; extra == 'easy'
+  - pillow ; extra == 'easy'
+  - vhacdx ; extra == 'easy'
+  - xatlas ; extra == 'easy'
+  - glooey ; extra == 'recommend'
+  - sympy ; extra == 'recommend'
+  - meshio ; extra == 'recommend'
+  - pyglet<2 ; extra == 'recommend'
+  - psutil ; extra == 'recommend'
+  - scikit-image ; extra == 'recommend'
+  - python-fcl ; extra == 'recommend'
+  - openctm ; extra == 'recommend'
+  - cascadio ; extra == 'recommend'
+  - manifold3d>=2.3.0 ; extra == 'recommend'
+  - pytest-cov ; extra == 'test'
+  - coveralls ; extra == 'test'
+  - pyright ; extra == 'test'
+  - ezdxf ; extra == 'test'
+  - gmsh>=4.12.1 ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pymeshlab ; extra == 'test'
+  - pyinstrument ; extra == 'test'
+  - matplotlib ; extra == 'test'
+  - ruff ; extra == 'test'
+  - pytest-beartype ; python_version >= '3.10' and extra == 'test'
+  requires_python: '>=3.7'
+- kind: conda
   name: typing-extensions
   version: 4.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - typing_extensions 4.9.0 pyha770c72_0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
-  hash:
-    md5: c16524c1b7227dc80b36b4fa6f77cc86
-    sha256: d795c1eb1db4ea147f01ece74e5a504d7c2e8d5ee8c11ec987884967dd938f9c
   build: hd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
+  sha256: d795c1eb1db4ea147f01ece74e5a504d7c2e8d5ee8c11ec987884967dd938f9c
+  md5: c16524c1b7227dc80b36b4fa6f77cc86
+  depends:
+  - typing_extensions 4.9.0 pyha770c72_0
+  arch: aarch64
+  platform: osx
   license: PSF-2.0
   license_family: PSF
-  noarch: python
   size: 10191
   timestamp: 1702176301116
-- platform: osx-arm64
-  name: typing-extensions
-  version: 4.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - typing_extensions 4.9.0 pyha770c72_0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
-  hash:
-    md5: c16524c1b7227dc80b36b4fa6f77cc86
-    sha256: d795c1eb1db4ea147f01ece74e5a504d7c2e8d5ee8c11ec987884967dd938f9c
-  build: hd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
-  noarch: python
-  size: 10191
-  timestamp: 1702176301116
-- platform: linux-64
+- kind: conda
   name: typing_extensions
   version: 4.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
-  hash:
-    md5: a92a6440c3fe7052d63244f3aba2a4a7
-    sha256: f3c5be8673bfd905c4665efcb27fa50192f24f84fa8eff2f19cba5d09753d905
   build: pyha770c72_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
+  sha256: f3c5be8673bfd905c4665efcb27fa50192f24f84fa8eff2f19cba5d09753d905
+  md5: a92a6440c3fe7052d63244f3aba2a4a7
+  depends:
+  - python >=3.8
+  arch: aarch64
+  platform: osx
   license: PSF-2.0
   license_family: PSF
-  noarch: python
+  purls:
+  - pkg:pypi/typing-extensions
   size: 36058
   timestamp: 1702176292645
-- platform: osx-arm64
-  name: typing_extensions
-  version: 4.9.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
-  hash:
-    md5: a92a6440c3fe7052d63244f3aba2a4a7
-    sha256: f3c5be8673bfd905c4665efcb27fa50192f24f84fa8eff2f19cba5d09753d905
-  build: pyha770c72_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: PSF-2.0
-  license_family: PSF
-  noarch: python
-  size: 36058
-  timestamp: 1702176292645
-- platform: linux-64
+- kind: conda
   name: tzdata
   version: 2023c
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  hash:
-    md5: 939e3e74d8be4dac89ce83b20de2492a
-    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
   build: h71feb2d_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: LicenseRef-Public-Domain
+  subdir: osx-arm64
   noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+  sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
+  md5: 939e3e74d8be4dac89ce83b20de2492a
+  arch: aarch64
+  platform: osx
+  license: LicenseRef-Public-Domain
   size: 117580
   timestamp: 1680041306008
-- platform: osx-arm64
-  name: tzdata
-  version: 2023c
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  hash:
-    md5: 939e3e74d8be4dac89ce83b20de2492a
-    sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  build: h71feb2d_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: LicenseRef-Public-Domain
-  noarch: generic
-  size: 117580
-  timestamp: 1680041306008
-- platform: linux-64
-  name: ucx
-  version: 1.14.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libnuma >=2.0.16,<3.0a0
-  - libstdcxx-ng >=12
-  - rdma-core >=28.9,<29.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.14.1-h64cca9d_5.conda
-  hash:
-    md5: 39aa3b356d10d7e5add0c540945a0944
-    sha256: a62f3fb56849dc37270f9078e1c8ba32328bc3ba4d32cf1f7dace48b431d5abe
-  build: h64cca9d_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  constrains:
-  - cuda-version >=11.2,<12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 15210025
-  timestamp: 1695214404131
-- platform: linux-64
-  name: unicodedata2
-  version: 15.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.1.0-py310h2372a71_0.conda
-  hash:
-    md5: 72637c58d36d9475fda24700c9796f19
-    sha256: 5ab2f2d4542ba0cc27d222c08ae61706babe7173b0c6dfa748aa37ff2fa9d824
-  build: py310h2372a71_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 374055
-  timestamp: 1695848183607
-- platform: osx-arm64
-  name: unicodedata2
-  version: 15.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.1.0-py310h2aa6e3c_0.conda
-  hash:
-    md5: 9dbba0c13148e8efbb80eb60186b2d8c
-    sha256: fd33715a75bc7d4ad863ac47341e9fdf8b78e47aa55c90f89a844c660aacc352
-  build: py310h2aa6e3c_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 377237
-  timestamp: 1695848435303
-- platform: linux-64
+- kind: conda
   name: urllib3
   version: 2.1.0
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+  sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
+  md5: f8ced8ee63830dec7ecc1be048d1470a
+  depends:
   - brotli-python >=1.0.9
   - pysocks >=1.5.6,<2.0,!=1.5.7
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f8ced8ee63830dec7ecc1be048d1470a
-    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/urllib3
   size: 85324
   timestamp: 1699933655057
-- platform: osx-arm64
-  name: urllib3
-  version: 2.1.0
-  category: main
-  manager: conda
-  dependencies:
-  - brotli-python >=1.0.9
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: f8ced8ee63830dec7ecc1be048d1470a
-    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 85324
-  timestamp: 1699933655057
-- platform: linux-64
+- kind: pypi
+  name: wcwidth
+  version: 0.2.13
+  url: https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl
+  sha256: 3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859
+  requires_dist:
+  - backports-functools-lru-cache>=1.2.1 ; python_version < '3.2'
+- kind: conda
   name: werkzeug
   version: 3.0.1
-  category: main
-  manager: conda
-  dependencies:
+  build: pyhd8ed1ab_0
+  subdir: osx-arm64
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
+  sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
+  md5: af8d825d93dbe6331ee6d61c69869ca0
+  depends:
   - markupsafe >=2.1.1
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: af8d825d93dbe6331ee6d61c69869ca0
-    sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  noarch: python
+  purls:
+  - pkg:pypi/werkzeug
   size: 241704
   timestamp: 1698235401441
-- platform: osx-arm64
-  name: werkzeug
-  version: 3.0.1
-  category: main
-  manager: conda
-  dependencies:
-  - markupsafe >=2.1.1
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: af8d825d93dbe6331ee6d61c69869ca0
-    sha256: b7ac49549d370a411b1d6150d24243a15adcce07f1c61ec2ea1b536346e47aa0
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  noarch: python
-  size: 241704
-  timestamp: 1698235401441
-- platform: linux-64
+- kind: pypi
   name: wheel
-  version: 0.42.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
-  build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 57553
-  timestamp: 1701013309664
-- platform: osx-arm64
-  name: wheel
-  version: 0.42.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
-  build: pyhd8ed1ab_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 57553
-  timestamp: 1701013309664
-- platform: osx-arm64
+  version: 0.43.0
+  url: https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl
+  sha256: 55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81
+  requires_dist:
+  - pytest>=6.0.0 ; extra == 'test'
+  - setuptools>=65 ; extra == 'test'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: widgetsnbextension
+  version: 4.0.10
+  url: https://files.pythonhosted.org/packages/99/bc/82a8c3985209ca7c0a61b383c80e015fd92e74f8ba0ec1af98f9d6ca8dce/widgetsnbextension-4.0.10-py3-none-any.whl
+  sha256: d37c3724ec32d8c48400a435ecfa7d3e259995201fbefa37163124a9fcb393cc
+  requires_python: '>=3.7'
+- kind: conda
   name: x264
   version: 1!164.3095
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
-  hash:
-    md5: b1f6dccde5d3a1f911960b6e567113ff
-    sha256: debdf60bbcfa6a60201b12a1d53f36736821db281a28223a09e0685edcce105a
   build: h57fd34a_2
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
+  sha256: debdf60bbcfa6a60201b12a1d53f36736821db281a28223a09e0685edcce105a
+  md5: b1f6dccde5d3a1f911960b6e567113ff
+  arch: aarch64
+  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL
   size: 717038
   timestamp: 1660323292329
-- platform: osx-arm64
+- kind: conda
   name: x265
   version: '3.5'
-  category: main
-  manager: conda
-  dependencies:
-  - libcxx >=12.0.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
-  hash:
-    md5: b1f7f2780feffe310b068c021e8ff9b2
-    sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
   build: hbc6ce65_3
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+  sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
+  md5: b1f7f2780feffe310b068c021e8ff9b2
+  depends:
+  - libcxx >=12.0.1
+  arch: aarch64
+  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL
   size: 1832744
   timestamp: 1646609481185
-- platform: linux-64
-  name: xcb-util
-  version: 0.4.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.3.0
-  - libxcb >=1.13
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-h516909a_0.tar.bz2
-  hash:
-    md5: a88ab22508ba067b689dc12696157cee
-    sha256: d797cecb10d9d20970656db803186b2d87e51f58202a87a359b18bae6f0b0d1e
-  build: h516909a_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 20109
-  timestamp: 1574273086272
-- platform: linux-64
-  name: xcb-util-image
-  version: 0.4.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libxcb >=1.13
-  - libxcb >=1.13,<1.14.0a0
-  - xcb-util >=0.4.0,<0.5.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h166bdaf_0.tar.bz2
-  hash:
-    md5: c9b568bd804cb2903c6be6f5f68182e4
-    sha256: 6db358d4afa0eb1225e24871f6c64c1b6c433f203babdd43508b0d61252467d1
-  build: h166bdaf_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 24256
-  timestamp: 1654738819647
-- platform: linux-64
-  name: xcb-util-keysyms
-  version: 0.4.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.3.0
-  - libxcb >=1.13
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h516909a_0.tar.bz2
-  hash:
-    md5: d04a6285315c4f03ebaf37355be272f9
-    sha256: cdb8ed921d076daed3c3d485370ea821c45eb95b858a587ff2a53d9271f1287c
-  build: h516909a_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 11763
-  timestamp: 1574268798739
-- platform: linux-64
-  name: xcb-util-renderutil
-  version: 0.3.9
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libxcb >=1.13
-  - libxcb >=1.13,<1.14.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-h166bdaf_0.tar.bz2
-  hash:
-    md5: 732e22f1741bccea861f5668cf7342a7
-    sha256: 19d27b7af8fb8047e044de2b87244337343c51fe7caa0fbaa9c53c2215787188
-  build: h166bdaf_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 15659
-  timestamp: 1654738584558
-- platform: linux-64
-  name: xcb-util-wm
-  version: 0.4.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=7.3.0
-  - libxcb >=1.13
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h516909a_0.tar.bz2
-  hash:
-    md5: 847df113dba16f0079758cacf9024409
-    sha256: 1ab62607ded0815b9a570e66a2af859cf4d9c79a3bfdd8b06f5d773fc1211ea5
-  build: h516909a_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 56020
-  timestamp: 1574276788949
-- platform: linux-64
-  name: xkeyboard-config
-  version: '2.38'
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.38-h0b41bf4_0.conda
-  hash:
-    md5: 9ac34337e5101a87e5d91da05d84aa48
-    sha256: 0518e65929deded6afc5f91f31febb15e8c93f7ee599a18b787f9fab3f79cfd6
-  build: h0b41bf4_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 882013
-  timestamp: 1676563054660
-- platform: linux-64
-  name: xorg-kbproto
-  version: 1.0.7
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
-  hash:
-    md5: 4b230e8381279d76131116660f5a241a
-    sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
-  build: h7f98852_1002
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1002
-  license: MIT
-  license_family: MIT
-  size: 27338
-  timestamp: 1610027759842
-- platform: linux-64
-  name: xorg-libice
-  version: 1.1.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
-  hash:
-    md5: b462a33c0be1421532f28bfe8f4a7514
-    sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 58469
-  timestamp: 1685307573114
-- platform: linux-64
-  name: xorg-libsm
-  version: 1.2.4
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libuuid >=2.38.1,<3.0a0
-  - xorg-libice >=1.1.1,<2.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
-  hash:
-    md5: 93ee23f12bc2e684548181256edd2cf6
-    sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
-  build: h7391055_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 27433
-  timestamp: 1685453649160
-- platform: linux-64
-  name: xorg-libx11
-  version: 1.8.4
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libxcb 1.*
-  - libxcb >=1.13,<1.14.0a0
-  - xorg-kbproto
-  - xorg-xextproto >=7.3.0,<8.0a0
-  - xorg-xproto
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.4-h0b41bf4_0.conda
-  hash:
-    md5: ea8fbfeb976ac49cbeb594e985393514
-    sha256: 3c6862a01a39cdea3870b132706ad7256824299947a3a94ae361d863d402d704
-  build: h0b41bf4_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 829872
-  timestamp: 1677611125385
-- platform: linux-64
+- kind: conda
   name: xorg-libxau
   version: 1.0.11
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
-  hash:
-    md5: 2c80dc38fface310c9bd81b17037fee5
-    sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
-  build: hd590300_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 14468
-  timestamp: 1684637984591
-- platform: osx-arm64
-  name: xorg-libxau
-  version: 1.0.11
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
-  hash:
-    md5: ca73dc4f01ea91e44e3ed76602c5ea61
-    sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
   build: hb547adb_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+  sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
+  md5: ca73dc4f01ea91e44e3ed76602c5ea61
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 13667
   timestamp: 1684638272445
-- platform: linux-64
-  name: xorg-libxdmcp
-  version: 1.1.3
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
-  hash:
-    md5: be93aabceefa2fac576e971aef407908
-    sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
-  build: h7f98852_0
-  arch: x86_64
+- kind: conda
+  name: xorg-libxau
+  version: 1.0.11
+  build: hd590300_0
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+  sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
+  md5: 2c80dc38fface310c9bd81b17037fee5
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: MIT
   license_family: MIT
-  size: 19126
-  timestamp: 1610071769228
-- platform: osx-arm64
+  size: 14468
+  timestamp: 1684637984591
+- kind: conda
   name: xorg-libxdmcp
   version: 1.1.3
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
-  hash:
-    md5: 6738b13f7fadc18725965abdd4129c36
-    sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
   build: h27ca646_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+  sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
+  md5: 6738b13f7fadc18725965abdd4129c36
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 18164
   timestamp: 1610071737668
-- platform: linux-64
-  name: xorg-libxext
-  version: 1.3.4
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.7.2,<2.0a0
-  - xorg-xextproto
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
-  hash:
-    md5: 82b6df12252e6f32402b96dacc656fec
-    sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
-  build: h0b41bf4_2
-  arch: x86_64
+- kind: conda
+  name: xorg-libxdmcp
+  version: 1.1.3
+  build: h7f98852_0
   subdir: linux-64
-  build_number: 2
-  license: MIT
-  license_family: MIT
-  size: 50143
-  timestamp: 1677036907815
-- platform: linux-64
-  name: xorg-libxrender
-  version: 0.9.10
-  category: main
-  manager: conda
-  dependencies:
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+  sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+  md5: be93aabceefa2fac576e971aef407908
+  depends:
   - libgcc-ng >=9.3.0
-  - xorg-libx11 >=1.7.0,<2.0a0
-  - xorg-renderproto
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.10-h7f98852_1003.tar.bz2
-  hash:
-    md5: f59c1242cc1dd93e72c2ee2b360979eb
-    sha256: 7d907ed9e2ec5af5d7498fb3ab744accc298914ae31497ab6dcc6ef8bd134d00
-  build: h7f98852_1003
   arch: x86_64
-  subdir: linux-64
-  build_number: 1003
+  platform: linux
   license: MIT
   license_family: MIT
-  size: 32906
-  timestamp: 1614866792944
-- platform: linux-64
-  name: xorg-renderproto
-  version: 0.11.1
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
-  hash:
-    md5: 06feff3d2634e3097ce2fe681474b534
-    sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
-  build: h7f98852_1002
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1002
-  license: MIT
-  license_family: MIT
-  size: 9621
-  timestamp: 1614866326326
-- platform: linux-64
-  name: xorg-xextproto
-  version: 7.3.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
-  hash:
-    md5: bce9f945da8ad2ae9b1d7165a64d0f87
-    sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
-  build: h0b41bf4_1003
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1003
-  license: MIT
-  license_family: MIT
-  size: 30270
-  timestamp: 1677036833037
-- platform: linux-64
-  name: xorg-xproto
-  version: 7.0.31
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
-  hash:
-    md5: b4a4381d54784606820704f7b5f05a15
-    sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
-  build: h7f98852_1007
-  arch: x86_64
-  subdir: linux-64
-  build_number: 1007
-  license: MIT
-  license_family: MIT
-  size: 74922
-  timestamp: 1607291557628
-- platform: linux-64
+  size: 19126
+  timestamp: 1610071769228
+- kind: conda
   name: xz
   version: 5.2.6
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
-  hash:
-    md5: 2161070d867d1b1204ea749c8eec4ef0
-    sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
   build: h166bdaf_0
-  arch: x86_64
   subdir: linux-64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+  sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+  md5: 2161070d867d1b1204ea749c8eec4ef0
+  depends:
+  - libgcc-ng >=12
+  arch: x86_64
+  platform: linux
   license: LGPL-2.1 and GPL-2.0
   size: 418368
   timestamp: 1660346797927
-- platform: osx-arm64
+- kind: conda
   name: xz
   version: 5.2.6
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
-  hash:
-    md5: 39c6b54e94014701dd157f4f576ed211
-    sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
   build: h57fd34a_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  arch: aarch64
+  platform: osx
   license: LGPL-2.1 and GPL-2.0
   size: 235693
   timestamp: 1660346961024
-- platform: linux-64
+- kind: conda
   name: yaml
   version: 0.2.5
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=9.4.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
-  hash:
-    md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
-    sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
-  build: h7f98852_2
-  arch: x86_64
-  subdir: linux-64
-  build_number: 2
-  license: MIT
-  license_family: MIT
-  size: 89141
-  timestamp: 1641346969816
-- platform: osx-arm64
-  name: yaml
-  version: 0.2.5
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
-  hash:
-    md5: 4bb3f014845110883a3c5ee811fd84b4
-    sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
   build: h3422bc3_2
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
+  sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
+  md5: 4bb3f014845110883a3c5ee811fd84b4
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
   size: 88016
   timestamp: 1641347076660
-- platform: linux-64
+- kind: conda
+  name: yaml
+  version: 0.2.5
+  build: h7f98852_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
+  sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
+  md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
+  depends:
+  - libgcc-ng >=9.4.0
+  arch: x86_64
+  platform: linux
+  license: MIT
+  license_family: MIT
+  size: 89141
+  timestamp: 1641346969816
+- kind: conda
   name: yarl
-  version: 1.9.3
-  category: main
-  manager: conda
-  dependencies:
+  version: 1.9.4
+  build: py39h17cfd9d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.9.4-py39h17cfd9d_0.conda
+  sha256: be088ed67246f51deb9a025617408bc8c80845d861f5695d9633aaca3b9fc555
+  md5: 28614a7a52d6907a1e79ef6706e07400
+  depends:
+  - idna >=2.0
+  - multidict >=4.0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/yarl
+  size: 104516
+  timestamp: 1705508794769
+- kind: conda
+  name: yarl
+  version: 1.9.4
+  build: py39hd1e30aa_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.4-py39hd1e30aa_0.conda
+  sha256: a0370c724d347103ae1a7c8a49166cc69359d80055c11bc5d7222d259efd8f12
+  md5: 7288bccf99dd979dfcf80bb372c3de3f
+  depends:
   - idna >=2.0
   - libgcc-ng >=12
   - multidict >=4.0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.9.3-py310h2372a71_0.conda
-  hash:
-    md5: 10246f66639d9ca55e790410f0dbb465
-    sha256: 159e9e292f841477dd1e4c897c055d364472720c79b16fa329faee1e7b878564
-  build: py310h2372a71_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
   license: Apache-2.0
   license_family: Apache
-  size: 113430
-  timestamp: 1701168756151
-- platform: osx-arm64
-  name: yarl
-  version: 1.9.3
-  category: main
-  manager: conda
-  dependencies:
-  - idna >=2.0
-  - multidict >=4.0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.9.3-py310hd125d64_0.conda
-  hash:
-    md5: 7b129f3311a4c3be8dacf8fd742e9b33
-    sha256: 637aafb906c3cfadb607669e1f67fb62d728dbb03ee451daf03d0a294ffcd630
-  build: py310hd125d64_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: Apache-2.0
-  license_family: Apache
-  size: 102499
-  timestamp: 1701169120992
-- platform: linux-64
+  purls:
+  - pkg:pypi/yarl
+  size: 115286
+  timestamp: 1705508499991
+- kind: conda
   name: zipp
   version: 3.17.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   build: pyhd8ed1ab_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  noarch: python
-  size: 18954
-  timestamp: 1695255262261
-- platform: osx-arm64
-  name: zipp
-  version: 3.17.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  build: pyhd8ed1ab_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
+  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  depends:
+  - python >=3.8
+  arch: aarch64
+  platform: osx
   license: MIT
   license_family: MIT
-  noarch: python
+  purls:
+  - pkg:pypi/zipp
   size: 18954
   timestamp: 1695255262261
-- platform: linux-64
+- kind: conda
   name: zlib
   version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libzlib 1.2.13 hd590300_5
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
-  hash:
-    md5: 68c34ec6149623be41a1933ab996a209
-    sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
-  build: hd590300_5
-  arch: x86_64
-  subdir: linux-64
-  build_number: 5
-  license: Zlib
-  license_family: Other
-  size: 92825
-  timestamp: 1686575231103
-- platform: osx-arm64
-  name: zlib
-  version: 1.2.13
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib 1.2.13 h53f4e23_5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
-  hash:
-    md5: a08383f223b10b71492d27566fafbf6c
-    sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
   build: h53f4e23_5
-  arch: aarch64
-  subdir: osx-arm64
   build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+  sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
+  md5: a08383f223b10b71492d27566fafbf6c
+  depends:
+  - libzlib 1.2.13 h53f4e23_5
+  arch: aarch64
+  platform: osx
   license: Zlib
   license_family: Other
   size: 79577
   timestamp: 1686575471024
-- platform: linux-64
-  name: zstd
-  version: 1.5.5
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
-  hash:
-    md5: 04b88013080254850d6c01ed54810589
-    sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
-  build: hfc55251_0
-  arch: x86_64
+- kind: conda
+  name: zlib
+  version: 1.2.13
+  build: hd590300_5
+  build_number: 5
   subdir: linux-64
-  build_number: 0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 545199
-  timestamp: 1693151163452
-- platform: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+  sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
+  md5: 68c34ec6149623be41a1933ab996a209
+  depends:
+  - libgcc-ng >=12
+  - libzlib 1.2.13 hd590300_5
+  arch: x86_64
+  platform: linux
+  license: Zlib
+  license_family: Other
+  size: 92825
+  timestamp: 1686575231103
+- kind: conda
   name: zstd
   version: 1.5.5
-  category: main
-  manager: conda
-  dependencies:
-  - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
-  hash:
-    md5: 5b212cfb7f9d71d603ad891879dc7933
-    sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
   build: h4f39d0f_0
-  arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+  sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
+  md5: 5b212cfb7f9d71d603ad891879dc7933
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: aarch64
+  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 400508
   timestamp: 1693151393180
+- kind: conda
+  name: zstd
+  version: 1.5.5
+  build: hfc55251_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
+  md5: 04b88013080254850d6c01ed54810589
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  arch: x86_64
+  platform: linux
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 545199
+  timestamp: 1693151163452

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,6 +6,11 @@ authors = ["Pablo Vela <pablovela5620@gmail.com>"]
 channels = ["nvidia", "pytorch", "conda-forge"]
 platforms = ["linux-64", "osx-arm64"]
 
+[system-requirements]
+macos = "11.0" # needed for some reason otherwise fails to resolve mediapipe package
+libc = "2.31"
+
+
 [tasks]
 download-hero-model = """
         bash -c '[ ! -f \"weights/hero_model.ckpt\" ] && gdown 1hCuKZjEq-AghrYAmFxJs_4eeixIlP488 -O weights/'
@@ -13,27 +18,34 @@ download-hero-model = """
 download-vdr-data = """
       bash -c '[ ! -d \"data/vdr\" ] && (gdown 1x-auV7vGCMdu5yZUMPcoP83p77QOuasT -O data/ && unzip data/vdr.zip -d data/) || echo \"Dataset already downloaded.\"'
 """
-
 download-data = {cmd="pwd", depends_on = ["download-hero-model", "download-vdr-data"]}
-post-install = "python -m pip install -r pixi-requirements.txt"
 
 [dependencies]
-python = "3.10.*"
+python = "3.9.*"
 pytorch = "1.13.1.*"
-torchvision = "0.14.1.*"
-kornia = "0.6.7.*"
-timm = ">=0.9.12,<0.10"
-trimesh = ">=4.0.5,<4.1"
-transforms3d = ">=0.4.1,<0.5"
-einops = ">=0.7.0,<0.8"
-pyrender = ">=0.1.45,<0.2"
-scipy = ">=1.11.4,<1.12"
-Pillow = ">=9.4.0,<9.5"
-tensorboard = ">=2.15.1,<2.16"
-matplotlib = ">=3.8.2,<3.9"
-rerun-sdk = ">=0.10.1,<0.11"
 pytorch-lightning = "1.5.4.*"
-pip = ">=23.3.1,<23.4"
+scipy = ">=1.11.4,<1.12"
+torchvision = "0.14.1.*"
+
+[pypi-dependencies]
+Pillow = ">=9.4.0,<9.5"
+antialiased-cnns = "*"
+efficientnet_pytorch = "*"
+einops = "*" # batching one liners
+gdown = ">=5.2.0"
+kornia = "==0.6.7" # gradients
+matplotlib = ">=3.8.2,<3.9"
+moviepy = "*"
+open3d = "*" # mesh fusion
+pip = "*"
+pyrender = "*"# rendering meshes
+scikit-image = "*"
+tensorboard = ">=2.15.1,<2.16"
+timm = "*" # efficent
+transforms3d = "*" # for NeuralRecon's arkit
+trimesh = "*" # mesh loading/storage, and mesh generation
+rerun-sdk = "==0.16.0-rc4"
+
 
 [target.linux-64.dependencies]
 pytorch-cuda = "11.7.*"

--- a/rerun_visualize_live_meshing.py
+++ b/rerun_visualize_live_meshing.py
@@ -18,7 +18,6 @@ from utils.geometry_utils import NormalGenerator
 
 import modules.cost_volume as cost_volume
 import rerun as rr
-from rerun.components import MeshProperties
 from utils.visualization_utils import reverse_imagenet_normalize, colormap_image
 
 
@@ -160,7 +159,7 @@ def log_rerun(
         f"{entity_path}/mesh",
         rr.Mesh3D(
             vertex_positions=scene_trimesh_mesh.vertices,
-            indices=scene_trimesh_mesh.faces,
+            triangle_indices=scene_trimesh_mesh.faces,
             vertex_colors=scene_trimesh_mesh.visual.vertex_colors,
         ),
     )


### PR DESCRIPTION
Move more things to `pixi.toml` and update to 0.16